### PR TITLE
Handle DateTimeOffset formatting

### DIFF
--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -187,6 +187,24 @@ namespace ObjectDumping.Internal
                 return;
             }
 
+            if (o is DateTimeOffset dateTimeOffset)
+            {
+                if (dateTimeOffset == DateTimeOffset.MinValue)
+                {
+                    this.Write($"DateTimeOffset.MinValue", intentLevel);
+                }
+                else if (dateTimeOffset == DateTimeOffset.MaxValue)
+                {
+                    this.Write($"DateTimeOffset.MaxValue", intentLevel);
+                }
+                else
+                {
+                    this.Write($"DateTimeOffset.ParseExact(\"{dateTimeOffset:O}\", \"O\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)", intentLevel);
+                }
+
+                return;
+            }
+
             if (o is Enum)
             {
                 this.Write($"{o.GetType().FullName}.{o}", intentLevel);

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -334,5 +334,50 @@ namespace ObjectDumping.Tests
 
             person.Should().BeEquivalentTo(expectedPerson);
         }
+
+        [Fact]
+        public void ShouldDumpDateTimeOffset()
+        {
+            // Arrange            
+            var offset = new DateTimeOffset(2000, 01, 01, 23, 59, 59, TimeSpan.Zero);
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(offset);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be($"var dateTimeOffset = DateTimeOffset.ParseExact(\"2000-01-01T23:59:59.0000000+00:00\", \"O\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);");
+        }
+
+        [Fact]
+        public void ShouldDumpDateTimeOffsetMinValue()
+        {
+            // Arrange            
+            var offset = DateTimeOffset.MinValue;
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(offset);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be($"var dateTimeOffset = DateTimeOffset.MinValue;");
+        }
+
+        [Fact]
+        public void ShouldDumpDateTimeOffsetMaxValue()
+        {
+            // Arrange            
+            var offset = DateTimeOffset.MaxValue;
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(offset);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be($"var dateTimeOffset = DateTimeOffset.MaxValue;");
+        }
     }
 }


### PR DESCRIPTION
Currently the CSharp dumber dumps DateTimeOffset values like this:

```
var dateTimeOffset = new DateTimeOffset`
{
  DateTime = DateTime.ParseExact("2000-01-01T23:59:59.0000000", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
  UtcDateTime = DateTime.ParseExact("2000-01-01T23:59:59.0000000Z", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
  LocalDateTime = DateTime.ParseExact("2000-01-02T12:59:59.0000000+13:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
  Date = DateTime.ParseExact("2000-01-01T00:00:00.0000000", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
  Day = 1,
  DayOfWeek = System.DayOfWeek.Saturday,
  DayOfYear = 1,
  Hour = 23,
  Millisecond = 0,
  Minute = 59,
  Month = 1,
  Offset = new TimeSpan
  {
    Ticks = 0L,
    Days = 0,
    Hours = 0,
    Milliseconds = 0,
    Minutes = 0,
    Seconds = 0,
    TotalDays = 0d,
    TotalHours = 0d,
    TotalMilliseconds = 0d,
    TotalMinutes = 0d,
    TotalSeconds = 0d
  },
  Second = 59,
  Ticks = 630823679990000000L,
  UtcTicks = 630823679990000000L,
  TimeOfDay = new TimeSpan
  {
    Ticks = 863990000000L,
    Days = 0,
    Hours = 23,
    Milliseconds = 0,
    Minutes = 59,
    Seconds = 59,
    TotalDays = 0.999988425925926d,
    TotalHours = 23.9997222222222d,
    TotalMilliseconds = 86399000d,
    TotalMinutes = 1439.98333333333d,
    TotalSeconds = 86399d
  },
  Year = 2000
};
```

instead of something small like:
```
DateTimeOffset.ParseExact("2000-01-01T23:59:59.0000000+00:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
```