### PR TITLE
Add ability to write properties that return Type without stack overflow.

### DIFF
--- a/ObjectDumper.sln.DotSettings
+++ b/ObjectDumper.sln.DotSettings
@@ -114,4 +114,5 @@
 	<s:String x:Key="/Default/Housekeeping/Layout/DialogWindows/OptionsDialog/SelectedPageId/@EntryValue">CsharpFileLayout</s:String>
 	<s:String x:Key="/Default/Housekeeping/Layout/DialogWindows/RefactoringWizardWindow/Location/@EntryValue">-242,-559</s:String>
 	<s:Int64 x:Key="/Default/Housekeeping/TreeModelBrowserPanelPersistance/PreviewSplitterVerticalPosition/=UnitTestSessionDescriptor/@EntryIndexedValue">300</s:Int64>
-	<s:Boolean x:Key="/Default/Housekeeping/UpgradeFromExceptionReport/UpgradePerformed/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Housekeeping/UpgradeFromExceptionReport/UpgradePerformed/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Testdata/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -68,25 +68,11 @@ public class CustomInstanceFormatters
         return this.customFormatters.ContainsKey(obj.GetType());
     }
 
-    public bool TryGetFormatter<T>(out Func<T, string> formatter)
+    public bool TryGetFormatter(Type type, out Func<object, string> formatter)
     {
-        if (this.HasFormatterFor<T>())
+        if (this.customFormatters.TryGetValue(type, out var customInstanceFormatter))
         {
-            formatter = o =>
-                this.customFormatters[typeof(T)].Formatter(o);
-
-            return true;
-        }
-
-        formatter = null;
-        return false;
-    }
-
-    public bool TryGetFormatter(object obj, out Func<object, string> formatter)
-    {
-        if (this.HasFormatterFor(obj))
-        {
-            formatter = this.customFormatters[obj.GetType()].Formatter;
+            formatter = customInstanceFormatter.Formatter;
             return true;
         }
 
@@ -99,12 +85,12 @@ public class CustomInstanceFormatters
         this.customFormatters.Clear();
     }
 
-    void RemoveFormatter<T>()
+    public void RemoveFormatter<T>()
     {
         this.RemoveFormatter(typeof(T));
     }
 
-    void RemoveFormatter(Type type)
+    public void RemoveFormatter(Type type)
     {
         this.customFormatters.Remove(type);
     }

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -19,6 +19,7 @@ public class DumpOptions
         this.IgnoreDefaultValues = false;
         this.CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>();
         this.CustomInstanceFormatters = new CustomInstanceFormatters();
+        this.TrimInitialVariableName = false;
     }
 
     public DumpStyle DumpStyle { get; set; }
@@ -40,6 +41,9 @@ public class DumpOptions
     public Expression<Func<PropertyInfo, object>> PropertyOrderBy { get; set; }
 
     public bool IgnoreDefaultValues { get; set; }
+
+    public bool TrimInitialVariableName { get; set; }
+    public bool TrimTrailingColonName { get; set; }
 
     public CustomInstanceFormatters CustomInstanceFormatters { get; }
 }

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -17,6 +17,7 @@ public class DumpOptions
         this.ExcludeProperties = new HashSet<string>();
         this.PropertyOrderBy = null;
         this.IgnoreDefaultValues = false;
+        this.CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>();
     }
 
     public DumpStyle DumpStyle { get; set; }
@@ -32,6 +33,8 @@ public class DumpOptions
     public int MaxLevel { get; set; }
 
     public ICollection<string> ExcludeProperties { get; set; }
+
+    public IDictionary<Type, Func<Type, string>> CustomTypeFormatter { get; set; }
 
     public Expression<Func<PropertyInfo, object>> PropertyOrderBy { get; set; }
 

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -18,6 +18,7 @@ public class DumpOptions
         this.PropertyOrderBy = null;
         this.IgnoreDefaultValues = false;
         this.CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>();
+        this.CustomInstanceFormatters = new CustomInstanceFormatters();
     }
 
     public DumpStyle DumpStyle { get; set; }
@@ -39,4 +40,80 @@ public class DumpOptions
     public Expression<Func<PropertyInfo, object>> PropertyOrderBy { get; set; }
 
     public bool IgnoreDefaultValues { get; set; }
+
+    public CustomInstanceFormatters CustomInstanceFormatters { get; }
+}
+
+public class CustomInstanceFormatters
+{
+    private readonly Dictionary<Type, CustomInstanceFormatter> customFormatters = new Dictionary<Type, CustomInstanceFormatter>();
+
+    public void AddFormatter<T>(Func<T, string> formatInstance)
+    {
+        this.customFormatters.Add(typeof(T), new CustomInstanceFormatter(typeof(T), o => formatInstance((T)o)));
+    }
+
+    public bool HasFormatterFor<T>()
+    {
+        return this.customFormatters.ContainsKey(typeof(T));
+    }
+
+    public bool HasFormatterFor(object obj)
+    {
+        return this.customFormatters.ContainsKey(obj.GetType());
+    }
+
+    public bool TryGetFormatter<T>(out Func<T, string> formatter)
+    {
+        if (this.HasFormatterFor<T>())
+        {
+            formatter = o =>
+                this.customFormatters[typeof(T)].Formatter(o);
+
+            return true;
+        }
+
+        formatter = null;
+        return false;
+    }
+
+    public bool TryGetFormatter(object obj, out Func<object, string> formatter)
+    {
+        if (this.HasFormatterFor(obj))
+        {
+            formatter = this.customFormatters[obj.GetType()].Formatter;
+            return true;
+        }
+
+        formatter = null;
+        return false;
+    }
+
+    public void Clear()
+    {
+        this.customFormatters.Clear();
+    }
+
+    void RemoveFormatter<T>()
+    {
+        RemoveFormatter(typeof(T));
+    }
+
+    void RemoveFormatter(Type type)
+    {
+        this.customFormatters.Remove(type);
+    }
+
+    private class CustomInstanceFormatter
+    {
+        public CustomInstanceFormatter(Type type, Func<object, string> formatter)
+        {
+            this.InstanceType = type;
+            this.Formatter = formatter;
+        }
+
+        public Func<object, string> Formatter { get; }
+
+        public Type InstanceType { get; }
+    }
 }

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -43,6 +43,7 @@ public class DumpOptions
     public bool IgnoreDefaultValues { get; set; }
 
     public bool TrimInitialVariableName { get; set; }
+
     public bool TrimTrailingColonName { get; set; }
 
     public CustomInstanceFormatters CustomInstanceFormatters { get; }
@@ -100,7 +101,7 @@ public class CustomInstanceFormatters
 
     void RemoveFormatter<T>()
     {
-        RemoveFormatter(typeof(T));
+        this.RemoveFormatter(typeof(T));
     }
 
     void RemoveFormatter(Type type)

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -245,6 +245,16 @@ namespace ObjectDumping.Internal
                 return;
             }
 
+            if (o is Type typ)
+            {
+                Func<Type, string> formatter;
+                if (this.DumpOptions.CustomTypeFormatter.TryGetValue(typ, out formatter) || this.DumpOptions.CustomTypeFormatter.TryGetValue(typeof(Type), out formatter))
+                {
+                    this.Write(formatter(typ));
+                    return;
+                }
+            }
+
             var type = o.GetType();
             var typeInfo = type.GetTypeInfo();
             if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -24,9 +24,15 @@ namespace ObjectDumping.Internal
             }
 
             var instance = new ObjectDumperCSharp(dumpOptions);
-            instance.Write($"var {GetVariableName(element)} = ");
+            if (!dumpOptions.TrimInitialVariableName)
+            {
+                instance.Write($"var {GetVariableName(element)} = ");
+            }
             instance.FormatValue(element);
-            instance.Write(";");
+            if (!dumpOptions.TrimTrailingColonName)
+            {
+                instance.Write(";");
+            }
 
             return instance.ToString();
         }

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -245,6 +245,17 @@ namespace ObjectDumping.Internal
                 return;
             }
 
+            if (this.DumpOptions.CustomInstanceFormatters.HasFormatterFor(o))
+            {
+                Func<object, string> func;
+                if (this.DumpOptions.CustomInstanceFormatters.TryGetFormatter(o, out func))
+                {
+                    this.Write(func(o));
+                    return;
+                }
+            }
+           
+
             if (o is Type typ)
             {
                 Func<Type, string> formatter;

--- a/Samples/ObjectDumperSample.Netfx/Person.cs
+++ b/Samples/ObjectDumperSample.Netfx/Person.cs
@@ -1,9 +1,13 @@
-﻿namespace ObjectDumperSample.Netfx
+﻿using System;
+
+namespace ObjectDumperSample.Netfx
 {
     public class Person
     {
         public string Name { get; set; }
 
         public int Age { get; set; }
+
+        public Type PersonType { get; set; }
     }
 }

--- a/Samples/ObjectDumperSample.Netfx/Program.cs
+++ b/Samples/ObjectDumperSample.Netfx/Program.cs
@@ -11,11 +11,11 @@ namespace ObjectDumperSample.Netfx
         {
             var persons = new List<Person>
             {
-                new Person { Name = "John", Age = 20, PersonType = typeof(Person)},
-                new Person { Name = "Thomas", Age = 30, PersonType = typeof(Person) },
+                new Person { Name = "John", Age = 20 },
+                new Person { Name = "Thomas", Age = 30 },
             };
 
-            var personsDump = ObjectDumper.Dump(persons, new DumpOptions() { DumpStyle = DumpStyle.CSharp, CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>() { { typeof(Type), o => $"typeof({o.Name})" } } });
+            var personsDump = ObjectDumper.Dump(persons, DumpStyle.CSharp);
 
             Console.WriteLine(personsDump);
             Console.ReadLine();

--- a/Samples/ObjectDumperSample.Netfx/Program.cs
+++ b/Samples/ObjectDumperSample.Netfx/Program.cs
@@ -11,11 +11,11 @@ namespace ObjectDumperSample.Netfx
         {
             var persons = new List<Person>
             {
-                new Person { Name = "John", Age = 20, },
-                new Person { Name = "Thomas", Age = 30, },
+                new Person { Name = "John", Age = 20, PersonType = typeof(Person)},
+                new Person { Name = "Thomas", Age = 30, PersonType = typeof(Person) },
             };
 
-            var personsDump = ObjectDumper.Dump(persons, DumpStyle.CSharp);
+            var personsDump = ObjectDumper.Dump(persons, new DumpOptions() { DumpStyle = DumpStyle.CSharp, CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>() { { typeof(Type), o => $"typeof({o.Name})" } } });
 
             Console.WriteLine(personsDump);
             Console.ReadLine();

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -495,12 +495,12 @@ namespace ObjectDumping.Tests
             };
 
             // Act
-            var dump = ObjectDumperCSharp.Dump(typeMap, 
+            var dump = ObjectDumperCSharp.Dump(typeMap,
                 new DumpOptions()
                 {
                     CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>()
                     {
-                        {typeof(Type), o=> $"typeof({o.Name})"}
+                        { typeof(Type), o => $"typeof({o.Name})" }
                     }
                 });
 
@@ -510,16 +510,14 @@ namespace ObjectDumping.Tests
             dump.Should().Be("var typeMap = new TypeMap\r\n{\r\n  Map = new Dictionary<Type, Type>\r\n  {\r\n    { typeof(KeyTypeOne), typeof(HandlerTypeOne) },\r\n    { typeof(KeyTypeTwo), typeof(HandlerTypeTwo) }\r\n  }\r\n};");
         }
 
-
         [Fact]
         public void ShouldDumpCustomConstructor()
         {
-
+            // Arrange 
             var myObj = ObjectWithComplexConstructorFactory.BuildIt("string", 1, 32.4F);
 
             var dumpOptions = new DumpOptions();
-
-            dumpOptions.CustomInstanceFormatters.AddFormatter<ObjectWithComplexConstructorFactory.ObjectWithComplexConstructor>(a=> $"ObjectWithComplexConstructorFactory.BuildIt(\"{a.Foo}\", {a.Bar}, {a.Baz})");
+            dumpOptions.CustomInstanceFormatters.AddFormatter<ObjectWithComplexConstructorFactory.ObjectWithComplexConstructor>(a => $"ObjectWithComplexConstructorFactory.BuildIt(\"{a.Foo}\", {a.Bar}, {a.Baz})");
 
             // Act
             var dump = ObjectDumperCSharp.Dump(myObj, dumpOptions);
@@ -533,14 +531,13 @@ namespace ObjectDumping.Tests
         [Fact]
         public void ShouldDumpTrimmedCustomConstructor()
         {
-
+            // Arrange 
             var myObj = ObjectWithComplexConstructorFactory.BuildIt("string", 1, 32.4F);
 
-            var dumpOptions = new DumpOptions()
+            var dumpOptions = new DumpOptions
             {
                 TrimInitialVariableName = true,
                 TrimTrailingColonName = true
-
             };
 
             dumpOptions.CustomInstanceFormatters.AddFormatter<ObjectWithComplexConstructorFactory.ObjectWithComplexConstructor>(a => $"ObjectWithComplexConstructorFactory.BuildIt(\"{a.Foo}\", {a.Bar}, {a.Baz})");

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -484,5 +484,30 @@ namespace ObjectDumping.Tests
             dump.Should().NotBeNull();
             dump.Should().Be("var cultureInfo = new CultureInfo(\"de-CH\");");
         }
+
+        [Fact]
+        public void ShouldDumpTypes()
+        {
+            // Arrange            
+            var typeMap = new TypeMap
+            {
+                Map = new Dictionary<Type, Type> { { typeof(KeyTypeOne), typeof(HandlerTypeOne) }, { typeof(KeyTypeTwo), typeof(HandlerTypeTwo) } }
+            };
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(typeMap, 
+                new DumpOptions()
+                {
+                    CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>()
+                    {
+                        {typeof(Type), o=> $"typeof({o.Name})"}
+                    }
+                });
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("var typeMap = new TypeMap\r\n{\r\n  Map = new Dictionary<Type, Type>\r\n  {\r\n    { typeof(KeyTypeOne), typeof(HandlerTypeOne) },\r\n    { typeof(KeyTypeTwo), typeof(HandlerTypeTwo) }\r\n  }\r\n};");
+        }
     }
 }

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -529,5 +529,29 @@ namespace ObjectDumping.Tests
             dump.Should().NotBeNull();
             dump.Should().Be("var objectWithComplexConstructor = ObjectWithComplexConstructorFactory.BuildIt(\"string\", 1, 32.4);");
         }
+
+        [Fact]
+        public void ShouldDumpTrimmedCustomConstructor()
+        {
+
+            var myObj = ObjectWithComplexConstructorFactory.BuildIt("string", 1, 32.4F);
+
+            var dumpOptions = new DumpOptions()
+            {
+                TrimInitialVariableName = true,
+                TrimTrailingColonName = true
+
+            };
+
+            dumpOptions.CustomInstanceFormatters.AddFormatter<ObjectWithComplexConstructorFactory.ObjectWithComplexConstructor>(a => $"ObjectWithComplexConstructorFactory.BuildIt(\"{a.Foo}\", {a.Bar}, {a.Baz})");
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(myObj, dumpOptions);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("ObjectWithComplexConstructorFactory.BuildIt(\"string\", 1, 32.4)");
+        }
     }
 }

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -486,23 +486,28 @@ namespace ObjectDumping.Tests
         }
 
         [Fact]
-        public void ShouldDumpTypes()
+        public void ShouldDumpTypes_UsingCustomTypeFormatter()
         {
             // Arrange            
             var typeMap = new TypeMap
             {
-                Map = new Dictionary<Type, Type> { { typeof(KeyTypeOne), typeof(HandlerTypeOne) }, { typeof(KeyTypeTwo), typeof(HandlerTypeTwo) } }
+                Map = new Dictionary<Type, Type>
+                {
+                    { typeof(KeyTypeOne), typeof(HandlerTypeOne) },
+                    { typeof(KeyTypeTwo), typeof(HandlerTypeTwo) }
+                }
+            };
+
+            var dumpOptions = new DumpOptions
+            {
+                CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>()
+                {
+                    { typeof(Type), o => $"typeof({o.Name})" }
+                }
             };
 
             // Act
-            var dump = ObjectDumperCSharp.Dump(typeMap,
-                new DumpOptions()
-                {
-                    CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>()
-                    {
-                        { typeof(Type), o => $"typeof({o.Name})" }
-                    }
-                });
+            var dump = ObjectDumperCSharp.Dump(typeMap, dumpOptions);
 
             // Assert
             this.testOutputHelper.WriteLine(dump);

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -509,5 +509,25 @@ namespace ObjectDumping.Tests
             dump.Should().NotBeNull();
             dump.Should().Be("var typeMap = new TypeMap\r\n{\r\n  Map = new Dictionary<Type, Type>\r\n  {\r\n    { typeof(KeyTypeOne), typeof(HandlerTypeOne) },\r\n    { typeof(KeyTypeTwo), typeof(HandlerTypeTwo) }\r\n  }\r\n};");
         }
+
+
+        [Fact]
+        public void ShouldDumpCustomConstructor()
+        {
+
+            var myObj = ObjectWithComplexConstructorFactory.BuildIt("string", 1, 32.4F);
+
+            var dumpOptions = new DumpOptions();
+
+            dumpOptions.CustomInstanceFormatters.AddFormatter<ObjectWithComplexConstructorFactory.ObjectWithComplexConstructor>(a=> $"ObjectWithComplexConstructorFactory.BuildIt(\"{a.Foo}\", {a.Bar}, {a.Baz})");
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(myObj, dumpOptions);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("var objectWithComplexConstructor = ObjectWithComplexConstructorFactory.BuildIt(\"string\", 1, 32.4);");
+        }
     }
 }

--- a/Tests/ObjectDumper.Tests/Testdata/ObjectWithComplexConstructor.cs
+++ b/Tests/ObjectDumper.Tests/Testdata/ObjectWithComplexConstructor.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ObjectDumping.Tests.Testdata
+{
+
+    public class ObjectWithComplexConstructorFactory
+    {
+        public class ObjectWithComplexConstructor
+        {
+            public string Foo { get; }
+
+            public int Bar { get; }
+
+            public float Baz { get; }
+
+            internal ObjectWithComplexConstructor(string foo, int bar, float baz)
+            {
+                Foo = foo;
+                Bar = bar;
+                Baz = baz;
+            }
+
+        }
+
+
+        public static ObjectWithComplexConstructor BuildIt(string foo, int bar, float baz)
+        {
+            return new ObjectWithComplexConstructor(foo, bar , baz);
+        }
+
+    }
+}

--- a/Tests/ObjectDumper.Tests/Testdata/ObjectWithComplexConstructor.cs
+++ b/Tests/ObjectDumper.Tests/Testdata/ObjectWithComplexConstructor.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ObjectDumping.Tests.Testdata
+﻿namespace ObjectDumping.Tests.Testdata
 {
-
     public class ObjectWithComplexConstructorFactory
     {
         public class ObjectWithComplexConstructor
@@ -17,18 +12,15 @@ namespace ObjectDumping.Tests.Testdata
 
             internal ObjectWithComplexConstructor(string foo, int bar, float baz)
             {
-                Foo = foo;
-                Bar = bar;
-                Baz = baz;
+                this.Foo = foo;
+                this.Bar = bar;
+                this.Baz = baz;
             }
-
         }
-
 
         public static ObjectWithComplexConstructor BuildIt(string foo, int bar, float baz)
         {
-            return new ObjectWithComplexConstructor(foo, bar , baz);
+            return new ObjectWithComplexConstructor(foo, bar, baz);
         }
-
     }
 }

--- a/Tests/ObjectDumper.Tests/Testdata/TypeMap.cs
+++ b/Tests/ObjectDumper.Tests/Testdata/TypeMap.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace ObjectDumping.Tests.Testdata
 {
@@ -9,25 +8,19 @@ namespace ObjectDumping.Tests.Testdata
         public Dictionary<Type, Type> Map { get; set; }
     }
 
-
     public class KeyTypeOne
     {
-
     }
 
     public class HandlerTypeOne
     {
-
     }
 
     public class KeyTypeTwo
     {
-
     }
 
     public class HandlerTypeTwo
     {
-
     }
-
 }

--- a/Tests/ObjectDumper.Tests/Testdata/TypeMap.cs
+++ b/Tests/ObjectDumper.Tests/Testdata/TypeMap.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ObjectDumping.Tests.Testdata
+{
+    public class TypeMap
+    {
+        public Dictionary<Type, Type> Map { get; set; }
+    }
+
+
+    public class KeyTypeOne
+    {
+
+    }
+
+    public class HandlerTypeOne
+    {
+
+    }
+
+    public class KeyTypeTwo
+    {
+
+    }
+
+    public class HandlerTypeTwo
+    {
+
+    }
+
+}


### PR DESCRIPTION
When writing out objects that have properties that return a Type, I was getting SOE or OOME. This patch allows you to override the handling and formatting of such properties  