### PR TITLE
Harmonization of code between ObjectDumperConsole and ObjectDumperCSharp

### DIFF
--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -21,6 +21,7 @@ public class DumpOptions
         this.CustomTypeFormatter = new Dictionary<Type, Func<Type, string>>();
         this.CustomInstanceFormatters = new CustomInstanceFormatters();
         this.TrimInitialVariableName = false;
+        this.UseTypeFullName = false;
     }
 
     public DumpStyle DumpStyle { get; set; }
@@ -58,6 +59,8 @@ public class DumpOptions
     public bool TrimTrailingColonName { get; set; }
 
     public CustomInstanceFormatters CustomInstanceFormatters { get; }
+
+    public bool UseTypeFullName { get;  set; }
 }
 
 public class CustomInstanceFormatters

--- a/ObjectDumper/Internal/DumperBase.cs
+++ b/ObjectDumper/Internal/DumperBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace ObjectDumping.Internal
@@ -8,6 +9,7 @@ namespace ObjectDumping.Internal
         private readonly List<int> hashListOfFoundElements;
         private readonly StringBuilder stringBuilder;
         private bool isNewLine;
+        private int level;
 
         protected DumperBase(DumpOptions dumpOptions)
         {
@@ -18,7 +20,19 @@ namespace ObjectDumping.Internal
             this.isNewLine = true;
         }
 
-        public int Level { get; set; }
+        public int Level
+        {
+            get => level;
+            set
+            {
+                if(value < 0)
+                {
+                    throw new ArgumentException("Level must not be a negative number", nameof(Level));
+                }
+
+                level = value;
+            }
+        }
 
         public bool IsMaxLevel()
         {

--- a/ObjectDumper/Internal/DumperBase.cs
+++ b/ObjectDumper/Internal/DumperBase.cs
@@ -111,5 +111,12 @@ namespace ObjectDumping.Internal
         {
             return this.stringBuilder.ToString();
         }
+
+        public string GetClassName(object o)
+        {
+            var type = o.GetType();
+            var className = type.GetFormattedName(this.DumpOptions.UseTypeFullName);
+            return className;
+        }
     }
 }

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -26,7 +26,7 @@ namespace ObjectDumping.Internal
             var instance = new ObjectDumperCSharp(dumpOptions);
             if (!dumpOptions.TrimInitialVariableName)
             {
-                instance.Write($"var {GetVariableName(element)} = ");
+                instance.Write($"var {instance.GetVariableName(element)} = ");
             }
 
             instance.FormatValue(element);
@@ -366,8 +366,6 @@ namespace ObjectDumping.Internal
             this.Level++;
             if (this.IsMaxLevel())
             {
-                ////this.StartLine("// Omitted code");
-                ////this.LineBreak();
                 this.Level--;
                 return;
             }
@@ -391,14 +389,7 @@ namespace ObjectDumping.Internal
             this.Level--;
         }
 
-        private static string GetClassName(object o)
-        {
-            var type = o.GetType();
-            var className = type.GetFormattedName();
-            return className;
-        }
-
-        private static string GetVariableName(object element)
+        private string GetVariableName(object element)
         {
             if (element == null)
             {

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -338,7 +338,10 @@ namespace ObjectDumping.Internal
                 //this.LineBreak();
             }
 
-            this.Level--;
+            if(Level > 0)
+            {
+                this.Level--;
+            }
         }
     }
 }

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
 namespace ObjectDumping.Internal
 {
-    /// <summary>
-    ///     Source: http://stackoverflow.com/questions/852181/c-printing-all-properties-of-an-object
-    /// </summary>
     internal class ObjectDumperConsole : DumperBase
     {
         public ObjectDumperConsole(DumpOptions dumpOptions) : base(dumpOptions)
@@ -23,217 +21,324 @@ namespace ObjectDumping.Internal
             }
 
             var instance = new ObjectDumperConsole(dumpOptions);
-            return instance.DumpElement(element);
+
+            instance.FormatValue(element);
+
+            return instance.ToString();
         }
 
-        private string DumpElement(object element)
+        private void CreateObject(object o, int intentLevel = 0)
         {
-            if (this.Level > this.DumpOptions.MaxLevel)
+            this.AddAlreadyTouched(o);
+
+            this.Write($"{{{GetClassName(o)}}}", intentLevel);
+            this.LineBreak();
+            this.Level++;
+
+            var properties = o.GetType().GetRuntimeProperties()
+                .Where(p => p.GetMethod != null && p.GetMethod.IsPublic && p.GetMethod.IsStatic == false)
+                .ToList();
+
+            if (this.DumpOptions.ExcludeProperties != null && this.DumpOptions.ExcludeProperties.Any())
             {
-                return this.ToString();
+                properties = properties
+                    .Where(p => !this.DumpOptions.ExcludeProperties.Contains(p.Name))
+                    .ToList();
             }
 
-            if (element == null || element is ValueType || element is string)
+            if (this.DumpOptions.SetPropertiesOnly)
             {
-                this.Write(this.FormatValue(element));
+                properties = properties
+                    .Where(p => p.SetMethod != null && p.SetMethod.IsPublic && p.SetMethod.IsStatic == false)
+                    .ToList();
             }
-            else
+
+            if (this.DumpOptions.IgnoreDefaultValues)
             {
-                var objectType = element.GetType();
-                if (!typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+                properties = properties
+                    .Where(p =>
+                    {
+                        var value = p.GetValue(o);
+                        var defaultValue = p.PropertyType.GetDefault();
+                        var isDefaultValue = Equals(value, defaultValue);
+                        return !isDefaultValue;
+                    })
+                    .ToList();
+            }
+
+            if (this.DumpOptions.PropertyOrderBy != null)
+            {
+                properties = properties.OrderBy(this.DumpOptions.PropertyOrderBy.Compile())
+                    .ToList();
+            }
+
+            var last = properties.LastOrDefault();
+
+            foreach (var property in properties)
+            {
+                var value = property.TryGetValue(o);
+
+                if (this.AlreadyTouched(value))
                 {
-                    this.Write(GetClassName(element));
-                    this.LineBreak();
-                    this.AddAlreadyTouched(element);
-                    this.Level++;
+                    continue;
                 }
 
-                if (element is IEnumerable enumerable)
+                var indexParameters = property.GetIndexParameters();
+                if (indexParameters.Length > 0)
                 {
-                    foreach (var item in enumerable)
+                    if (!this.DumpOptions.IgnoreIndexers)
                     {
-                        if (item is IEnumerable && !(item is string))
-                        {
-                            this.Level++;
-                            this.DumpElement(item);
-                            this.Level--;
-                        }
-                        else
-                        {
-                            if (!this.AlreadyTouched(item))
-                            {
-                                this.DumpElement(item);
-                            }
-                            else
-                            {
-                                this.Write($"{GetClassName(element)} <-- bidirectional reference found");
-                                this.LineBreak();
-                            }
-                        }
-
-                        this.LineBreak();
+                        DumpIntegerArrayIndexer(o, property, indexParameters);
                     }
                 }
                 else
                 {
-                    var publicFields = element.GetType().GetRuntimeFields().Where(f => !f.IsPrivate);
-                    foreach (var fieldInfo in publicFields)
+                    this.Write($"{property.Name}: ");
+                    this.FormatValue(value);
+                    if (!Equals(property, last))
                     {
-                        var value = fieldInfo.TryGetValue(element);
-
-                        if (fieldInfo.FieldType.GetTypeInfo().IsValueType || fieldInfo.FieldType == typeof(string))
-                        {
-                            this.Write($"{fieldInfo.Name}: {this.FormatValue(value)}");
-                            this.LineBreak();
-                        }
-                        else
-                        {
-                            var isEnumerable = typeof(IEnumerable).GetTypeInfo()
-                                .IsAssignableFrom(fieldInfo.FieldType.GetTypeInfo());
-                            this.Write($"{fieldInfo.Name}: {(isEnumerable ? "..." : (value != null ? "{ }" : "null"))}");
-                            this.LineBreak();
-
-                            if (value != null)
-                            {
-                                var alreadyTouched = !isEnumerable && this.AlreadyTouched(value);
-                                this.Level++;
-                                if (!alreadyTouched)
-                                {
-                                    this.DumpElement(value);
-                                }
-                                else
-                                {
-                                    this.Write($"{GetClassName(element)} <-- bidirectional reference found");
-                                    this.LineBreak();
-                                }
-
-                                this.Level--;
-                            }
-                        }
+                        this.LineBreak();
                     }
-
-                    var properties = element.GetType().GetRuntimeProperties()
-                        .Where(p => p.GetMethod != null && p.GetMethod.IsPublic && p.GetMethod.IsStatic == false)
-                        .ToList();
-
-                    if (this.DumpOptions.ExcludeProperties != null && this.DumpOptions.ExcludeProperties.Any())
-                    {
-                        properties = properties
-                            .Where(p => !this.DumpOptions.ExcludeProperties.Contains(p.Name))
-                            .ToList();
-                    }
-
-                    if (this.DumpOptions.SetPropertiesOnly)
-                    {
-                        properties = properties
-                            .Where(p => p.SetMethod != null && p.SetMethod.IsPublic && p.SetMethod.IsStatic == false)
-                            .ToList();
-                    }
-
-                    if (this.DumpOptions.IgnoreDefaultValues)
-                    {
-                        properties = properties
-                            .Where(p =>
-                            {
-                                var value = p.GetValue(element);
-                                var defaultValue = p.PropertyType.GetDefault();
-                                var isDefaultValue = Equals(value, defaultValue);
-                                return !isDefaultValue;
-                            })
-                            .ToList();
-                    }
-
-                    if (this.DumpOptions.PropertyOrderBy != null)
-                    {
-                        properties = properties.OrderBy(this.DumpOptions.PropertyOrderBy.Compile())
-                            .ToList();
-                    }
-
-                    foreach (var propertyInfo in properties)
-                    {
-                        var type = propertyInfo.PropertyType;
-                        var value = propertyInfo.TryGetValue(element);
-
-                        if (type.GetTypeInfo().IsValueType || type == typeof(string))
-                        {
-                            this.Write($"{propertyInfo.Name}: {this.FormatValue(value)}");
-                            this.LineBreak();
-                        }
-                        else
-                        {
-                            var isEnumerable = typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo());
-                            this.Write($"{propertyInfo.Name}: {(isEnumerable ? "..." : (value != null ? "{ }" : "null"))}");
-                            this.LineBreak();
-
-                            if (value != null)
-                            {
-                                var alreadyTouched = !isEnumerable && this.AlreadyTouched(value);
-                                this.Level++;
-                                if (!alreadyTouched)
-                                {
-                                    this.DumpElement(value);
-                                }
-                                else
-                                {
-                                    this.Write($"{GetClassName(element)} <-- bidirectional reference found");
-                                    this.LineBreak();
-                                }
-
-                                this.Level--;
-                            }
-                        }
-                    }
-                }
-
-                if (!typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
-                {
-                    this.Level--;
                 }
             }
 
-            return this.ToString();
+            this.Level--;
         }
 
-        private string FormatValue(object o)
+        private void DumpIntegerArrayIndexer(object o, PropertyInfo property, ParameterInfo[] indexParameters)
         {
+            if (indexParameters.Length == 1 && indexParameters[0].ParameterType == typeof(int))
+            {
+                // get an integer count value
+                // issues, what if it's not an integer index (Dictionary?), what if it's multi-dimensional?
+                // just need to be able to iterate through each value in the indexed property
+                // Source: https://stackoverflow.com/questions/4268244/iterating-through-an-indexed-property-reflection
+
+                var arrayValues = new List<object>();
+                var index = 0;
+                while (true)
+                {
+                    try
+                    {
+                        arrayValues.Add(property.GetValue(o, new object[] { index }));
+                        index++;
+                    }
+                    catch (TargetInvocationException) { break; }
+                }
+
+                var lastArrayValue = arrayValues.LastOrDefault();
+
+                for (var arrayIndex = 0; arrayIndex < arrayValues.Count; arrayIndex++)
+                {
+                    var arrayValue = arrayValues[arrayIndex];
+                    this.Write($"[{arrayIndex}]: ");
+                    FormatValue(arrayValue);
+                    if (!Equals(arrayValue, lastArrayValue))
+                    {
+                        this.Write($",{this.DumpOptions.LineBreakChar}");
+                    }
+                    else
+                    {
+                        this.Write($",");
+                    }
+                }
+
+                this.LineBreak();
+            }
+        }
+
+        private void FormatValue(object o, int intentLevel = 0)
+        {
+            if (this.IsMaxLevel())
+            {
+                return;
+            }
+
             if (o == null)
             {
-                return "null";
+                this.Write("null", intentLevel);
+                return;
+            }
+
+            if (o is bool)
+            {
+                this.Write($"{o.ToString().ToLower()}", intentLevel);
+                return;
             }
 
             if (o is string)
             {
-                return $"\"{o}\"";
+                var str = $@"{o}".Escape();
+                this.Write($"\"{str}\"", intentLevel);
+                return;
             }
 
-            if (o is char && (char)o == '\0')
+            if (o is char)
             {
-                return string.Empty;
+                var c = o.ToString().Replace("\0", "").Trim();
+                this.Write($"\'{c}\'", intentLevel);
+                return;
             }
 
-            if (o is ValueType)
+            if (o is double || o is decimal || o is byte || o is sbyte ||
+                o is float || o is int || o is uint || o is long || o is ulong || o is short || o is ushort)
             {
-                return o.ToString();
-            }
-            
-            if (o is CultureInfo)
-            {
-                return o.ToString();
+                this.Write($"{o}", intentLevel);
+                return;
             }
 
-            if (o is IEnumerable)
+            if (o is DateTime dateTime)
             {
-                return "...";
+                if (dateTime == DateTime.MinValue)
+                {
+                    this.Write($"DateTime.MinValue", intentLevel);
+                }
+                else if (dateTime == DateTime.MaxValue)
+                {
+                    this.Write($"DateTime.MaxValue", intentLevel);
+                }
+                else
+                {
+                    this.Write($"{dateTime}", intentLevel);
+                }
+
+                return;
             }
 
-            return "{ }";
+            if (o is DateTimeOffset dateTimeOffset)
+            {
+                if (dateTimeOffset == DateTimeOffset.MinValue)
+                {
+                    this.Write($"DateTimeOffset.MinValue", intentLevel);
+                }
+                else if (dateTimeOffset == DateTimeOffset.MaxValue)
+                {
+                    this.Write($"DateTimeOffset.MaxValue", intentLevel);
+                }
+                else
+                {
+                    this.Write($"{dateTimeOffset:O}", intentLevel);
+                }
+
+                return;
+            }
+
+            if (o is TimeSpan timeSpan)
+            {
+                if (timeSpan == TimeSpan.Zero)
+                {
+                    this.Write($"TimeSpan.Zero", intentLevel);
+                }
+                else if (timeSpan == TimeSpan.MinValue)
+                {
+                    this.Write($"TimeSpan.MinValue", intentLevel);
+                }
+                else if (timeSpan == TimeSpan.MaxValue)
+                {
+                    this.Write($"TimeSpan.MaxValue", intentLevel);
+                }
+                else
+                {
+                    this.Write($"{timeSpan:c}", intentLevel);
+                }
+
+                return;
+            }
+
+            if (o is CultureInfo cultureInfo)
+            {
+                this.Write($"{cultureInfo}", intentLevel);
+                return;
+            }
+
+            if (o is Enum)
+            {
+                this.Write($"{GetClassName(o)}.{o}", intentLevel);
+                return;
+            }
+
+            if (o is Guid guid)
+            {
+                this.Write($"{guid:B}", intentLevel);
+                return;
+            }
+
+            var type = o.GetType();
+            if (this.DumpOptions.CustomInstanceFormatters.TryGetFormatter(type, out var func))
+            {
+                this.Write(func(o));
+                return;
+            }
+
+            if (o is Type systemType)
+            {
+                if (this.DumpOptions.CustomTypeFormatter.TryGetValue(systemType, out var formatter) ||
+                    this.DumpOptions.CustomTypeFormatter.TryGetValue(typeof(Type), out formatter))
+                {
+                    this.Write(formatter(systemType));
+                    return;
+                }
+
+                this.Write($"{systemType.FullName}", intentLevel);
+                return;
+            }
+            var typeInfo = type.GetTypeInfo();
+            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+            {
+                var kvpKey = type.GetRuntimeProperty(nameof(KeyValuePair<object, object>.Key)).GetValue(o, null);
+                var kvpValue = type.GetRuntimeProperty(nameof(KeyValuePair<object, object>.Value)).GetValue(o, null);
+
+                this.Write("{ ", intentLevel);
+                this.FormatValue(kvpKey);
+                this.Write(", ");
+                this.FormatValue(kvpValue);
+                this.Write(" }");
+                return;
+            }
+
+            if (o is IEnumerable enumerable)
+            {
+                if (this.Level > 0)
+                {
+                    this.Write($"...", intentLevel);
+                    this.Level++;
+                }
+
+                this.WriteItems(enumerable);
+                return;
+            }
+
+            this.CreateObject(o, intentLevel);
         }
 
-        private static string GetClassName(object element)
+        private void WriteItems(IEnumerable items)
         {
-            var type = element.GetType();
-            var className = type.GetFormattedName(useFullName: true);
-            return $"{{{className}}}";
+            if (this.IsMaxLevel())
+            {
+                this.Level--;
+                return;
+            }
+
+            var e = items.GetEnumerator();
+            if (e.MoveNext())
+            {
+                if(this.Level > 0)
+                {
+                    this.LineBreak();
+                }
+                this.FormatValue(e.Current, this.Level);
+
+                while (e.MoveNext())
+                {
+                    this.LineBreak();
+
+                    this.FormatValue(e.Current, this.Level);
+                }
+
+                //this.LineBreak();
+            }
+
+            this.Level--;
         }
     }
 }

--- a/ObjectDumper/ObjectDumper.csproj
+++ b/ObjectDumper/ObjectDumper.csproj
@@ -33,7 +33,10 @@
     <Product>ObjectDumper.NET</Product>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RootNamespace>ObjectDumping</RootNamespace>
-    <PackageReleaseNotes>2.5.0
+    <PackageReleaseNotes>3.0.0
+- New formatting logic for DumpStyle.Console (default)
+
+2.5.0
 - Handle CultureInfo formatting
 - Extend GetFormattedName to handle nested generics and multi-dimensional arrays
 - Optimize variable naming for generic types

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -578,7 +578,8 @@ namespace ObjectDumping.Tests
         public void ShouldDumpArray_TwoDimensional()
         {
             // Arrange
-            var array = new int[3, 2]{
+            var array = new int[3, 2]
+            {
                 {1, 2},
                 {3, 4},
                 {5, 6}
@@ -590,7 +591,13 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("var array = new int[3, 2]{\r\n                {1, 2},\r\n                {3, 4},\r\n                {5, 6}\r\n            };");
+            dump.Should().Be(
+                "var array = new int[3, 2]\r\n" +
+                "{\r\n" +
+                "  {1, 2},\r\n" +
+                "  {3, 4},\r\n" +
+                "  {5, 6}\r\n" +
+                "};");
         }
 
         [Fact]

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -26,7 +26,7 @@ namespace ObjectDumping.Tests
         public void ShouldDumpObject()
         {
             // Arrange
-            var person = PersonFactory.GetPersonThomas();
+            var person = PersonFactory.GeneratePersons(count: 1).Single();
 
             // Act
             var dump = ObjectDumperCSharp.Dump(person);
@@ -34,7 +34,7 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("var person = new Person\r\n{\r\n  Name = \"Thomas\",\r\n  Char = '',\r\n  Age = 30,\r\n  GetOnly = 11,\r\n  Bool = false,\r\n  Byte = 0,\r\n  ByteArray = new Byte[]\r\n  {\r\n    1,\r\n    2,\r\n    3,\r\n    4\r\n  },\r\n  SByte = 0,\r\n  Float = 0f,\r\n  Uint = 0,\r\n  Long = 0L,\r\n  ULong = 0L,\r\n  Short = 0,\r\n  UShort = 0,\r\n  Decimal = 0m,\r\n  Double = 0d,\r\n  DateTime = DateTime.MinValue,\r\n  NullableDateTime = null,\r\n  Enum = System.DateTimeKind.Unspecified\r\n};");
+            dump.Should().Be("var person = new Person\r\n{\r\n  Name = \"Person 1\",\r\n  Char = '',\r\n  Age = 2,\r\n  GetOnly = 11,\r\n  Bool = false,\r\n  Byte = 0,\r\n  ByteArray = new Byte[]\r\n  {\r\n    1,\r\n    2,\r\n    3,\r\n    4\r\n  },\r\n  SByte = 0,\r\n  Float = 0f,\r\n  Uint = 0,\r\n  Long = 0L,\r\n  ULong = 0L,\r\n  Short = 0,\r\n  UShort = 0,\r\n  Decimal = 0m,\r\n  Double = 0d,\r\n  DateTime = DateTime.MinValue,\r\n  NullableDateTime = null,\r\n  Enum = System.DateTimeKind.Unspecified\r\n};");
         }
 
         [Fact]
@@ -71,7 +71,49 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("var listOfPersons = new List<Person>\r\n{\r\n  new Person\r\n  {\r\n    Name = \"Person 1\",\r\n    Char = '',\r\n    Age = 3,\r\n    GetOnly = 11,\r\n    Bool = false,\r\n    Byte = 0,\r\n    ByteArray = new Byte[]\r\n    {\r\n      1,\r\n      2,\r\n      3,\r\n      4\r\n    },\r\n    SByte = 0,\r\n    Float = 0f,\r\n    Uint = 0,\r\n    Long = 0L,\r\n    ULong = 0L,\r\n    Short = 0,\r\n    UShort = 0,\r\n    Decimal = 0m,\r\n    Double = 0d,\r\n    DateTime = DateTime.MinValue,\r\n    NullableDateTime = null,\r\n    Enum = System.DateTimeKind.Unspecified\r\n  },\r\n  new Person\r\n  {\r\n    Name = \"Person 2\",\r\n    Char = '',\r\n    Age = 3,\r\n    GetOnly = 11,\r\n    Bool = false,\r\n    Byte = 0,\r\n    ByteArray = new Byte[]\r\n    {\r\n      1,\r\n      2,\r\n      3,\r\n      4\r\n    },\r\n    SByte = 0,\r\n    Float = 0f,\r\n    Uint = 0,\r\n    Long = 0L,\r\n    ULong = 0L,\r\n    Short = 0,\r\n    UShort = 0,\r\n    Decimal = 0m,\r\n    Double = 0d,\r\n    DateTime = DateTime.MinValue,\r\n    NullableDateTime = null,\r\n    Enum = System.DateTimeKind.Unspecified\r\n  }\r\n};");
+            dump.Should().Be(
+                "var listOfPersons = new List<Person>\r\n" +
+                "{\r\n" +
+                "  new Person\r\n" +
+                "  {\r\n" +
+                "    Name = \"Person 1\",\r\n" +
+                "    Char = '',\r\n" +
+                "    Age = 3,\r\n" +
+                "    GetOnly = 11,\r\n" +
+                "    Bool = false,\r\n" +
+                "    Byte = 0,\r\n" +
+                "    ByteArray = new Byte[]\r\n" +
+                "    {\r\n      1,\r\n      2,\r\n      3,\r\n      4\r\n    },\r\n    SByte = 0,\r\n    Float = 0f,\r\n    Uint = 0,\r\n    Long = 0L,\r\n    ULong = 0L,\r\n    Short = 0,\r\n    UShort = 0,\r\n    Decimal = 0m,\r\n    Double = 0d,\r\n    DateTime = DateTime.MinValue,\r\n    NullableDateTime = null,\r\n    Enum = System.DateTimeKind.Unspecified\r\n" +
+                "  },\r\n" +
+                "  new Person\r\n" +
+                "  {\r\n" +
+                "    Name = \"Person 2\",\r\n" +
+                "    Char = '',\r\n" +
+                "    Age = 3,\r\n" +
+                "    GetOnly = 11,\r\n" +
+                "    Bool = false,\r\n" +
+                "    Byte = 0,\r\n" +
+                "    ByteArray = new Byte[]\r\n" +
+                "    {\r\n" +
+                "      1,\r\n" +
+                "      2,\r\n" +
+                "      3,\r\n" +
+                "      4\r\n" +
+                "    },\r\n" +
+                "    SByte = 0,\r\n" +
+                "    Float = 0f,\r\n" +
+                "    Uint = 0,\r\n" +
+                "    Long = 0L,\r\n" +
+                "    ULong = 0L,\r\n" +
+                "    Short = 0,\r\n" +
+                "    UShort = 0,\r\n" +
+                "    Decimal = 0m,\r\n" +
+                "    Double = 0d,\r\n" +
+                "    DateTime = DateTime.MinValue,\r\n" +
+                "    NullableDateTime = null,\r\n" +
+                "    Enum = System.DateTimeKind.Unspecified\r\n" +
+                "  }\r\n" +
+                "};");
         }
 
         [Fact]
@@ -87,7 +129,71 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("var organization = new Organization\r\n{\r\n  Name = \"superdev gmbh\",\r\n  Persons = new List<Person>\r\n  {\r\n    new Person\r\n    {\r\n      Name = \"Person 1\",\r\n      Char = '',\r\n      Age = 3,\r\n      GetOnly = 11,\r\n      Bool = false,\r\n      Byte = 0,\r\n      ByteArray = new Byte[]\r\n      {\r\n        1,\r\n        2,\r\n        3,\r\n        4\r\n      },\r\n      SByte = 0,\r\n      Float = 0f,\r\n      Uint = 0,\r\n      Long = 0L,\r\n      ULong = 0L,\r\n      Short = 0,\r\n      UShort = 0,\r\n      Decimal = 0m,\r\n      Double = 0d,\r\n      DateTime = DateTime.MinValue,\r\n      NullableDateTime = null,\r\n      Enum = System.DateTimeKind.Unspecified\r\n    },\r\n    new Person\r\n    {\r\n      Name = \"Person 2\",\r\n      Char = '',\r\n      Age = 3,\r\n      GetOnly = 11,\r\n      Bool = false,\r\n      Byte = 0,\r\n      ByteArray = new Byte[]\r\n      {\r\n        1,\r\n        2,\r\n        3,\r\n        4\r\n      },\r\n      SByte = 0,\r\n      Float = 0f,\r\n      Uint = 0,\r\n      Long = 0L,\r\n      ULong = 0L,\r\n      Short = 0,\r\n      UShort = 0,\r\n      Decimal = 0m,\r\n      Double = 0d,\r\n      DateTime = DateTime.MinValue,\r\n      NullableDateTime = null,\r\n      Enum = System.DateTimeKind.Unspecified\r\n    }\r\n  }\r\n};");
+            dump.Should().Be(
+                "var organization = new Organization\r\n" +
+                "{\r\n" +
+                "  Name = \"superdev gmbh\",\r\n" +
+                "  Persons = new List<Person>\r\n" +
+                "  {\r\n" +
+                "    new Person\r\n" +
+                "    {\r\n" +
+                "      Name = \"Person 1\",\r\n" +
+                "      Char = '',\r\n" +
+                "      Age = 3,\r\n" +
+                "      GetOnly = 11,\r\n" +
+                "      Bool = false,\r\n" +
+                "      Byte = 0,\r\n" +
+                "      ByteArray = new Byte[]\r\n" +
+                "      {\r\n" +
+                "        1,\r\n" +
+                "        2,\r\n" +
+                "        3,\r\n" +
+                "        4\r\n" +
+                "      },\r\n" +
+                "      SByte = 0,\r\n" +
+                "      Float = 0f,\r\n" +
+                "      Uint = 0,\r\n" +
+                "      Long = 0L,\r\n" +
+                "      ULong = 0L,\r\n" +
+                "      Short = 0,\r\n" +
+                "      UShort = 0,\r\n" +
+                "      Decimal = 0m,\r\n" +
+                "      Double = 0d,\r\n" +
+                "      DateTime = DateTime.MinValue,\r\n" +
+                "      NullableDateTime = null,\r\n" +
+                "      Enum = System.DateTimeKind.Unspecified\r\n" +
+                "    },\r\n" +
+                "    new Person\r\n" +
+                "    {\r\n" +
+                "      Name = \"Person 2\",\r\n" +
+                "      Char = '',\r\n" +
+                "      Age = 3,\r\n" +
+                "      GetOnly = 11,\r\n" +
+                "      Bool = false,\r\n" +
+                "      Byte = 0,\r\n" +
+                "      ByteArray = new Byte[]\r\n" +
+                "      {\r\n" +
+                "        1,\r\n" +
+                "        2,\r\n" +
+                "        3,\r\n" +
+                "        4\r\n" +
+                "      },\r\n" +
+                "      SByte = 0,\r\n" +
+                "      Float = 0f,\r\n" +
+                "      Uint = 0,\r\n" +
+                "      Long = 0L,\r\n" +
+                "      ULong = 0L,\r\n" +
+                "      Short = 0,\r\n" +
+                "      UShort = 0,\r\n" +
+                "      Decimal = 0m,\r\n" +
+                "      Double = 0d,\r\n" +
+                "      DateTime = DateTime.MinValue,\r\n" +
+                "      NullableDateTime = null,\r\n" +
+                "      Enum = System.DateTimeKind.Unspecified\r\n" +
+                "    }\r\n" +
+                "  },\r\n" +
+                "  IsAfterCollection = true\r\n" +
+                "};");
         }
 
         [Fact]
@@ -141,7 +247,15 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
 
             dump.Should().NotBeNull();
-            dump.Should().Be("var organization = new Organization\r\n{\r\n  Name = \"superdev gmbh\",\r\n  Persons = new List<Person>\r\n  {\r\n  }\r\n};");
+            dump.Should().Be(
+                "var organization = new Organization\r\n" +
+                "{\r\n" +
+                "  Name = \"superdev gmbh\",\r\n" +
+                "  Persons = new List<Person>\r\n" +
+                "  {\r\n" +
+                "  },\r\n" +
+                "  IsAfterCollection = true\r\n" +
+                "};");
         }
 
         [Fact]
@@ -436,7 +550,13 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("var dictionary = new Dictionary<Int32, String>\r\n{\r\n  { 1, \"Value1\" },\r\n  { 2, \"Value2\" },\r\n  { 3, \"Value3\" }\r\n};");
+            dump.Should().Be(
+                "var dictionary = new Dictionary<Int32, String>\r\n" +
+                "{\r\n" +
+                "  { 1, \"Value1\" },\r\n" +
+                "  { 2, \"Value2\" },\r\n" +
+                "  { 3, \"Value3\" }\r\n" +
+                "};");
         }
 
         [Fact]

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -247,10 +247,10 @@ namespace ObjectDumping.Tests
         }
 
         [Fact]
-        public void ShouldDumpMultipleGenericTypes()
+        public void ShouldDumpGenericClass_WithMultipleGenericTypeArguments()
         {
             // Arrange
-            var person = PersonFactory.GeneratePersons(count: 1).Single();
+            var person = PersonFactory.GeneratePersons(count: 1).First();
             var genericClass = new GenericClass<string, float, Person> { Prop1 = "Test", Prop2 = 123.45f, Prop3 = person };
 
             // Act
@@ -259,6 +259,7 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
+
             dump.Should().Be(
                 "{GenericClass<String, Single, Person>}\r\n" +
                 "  Prop1: \"Test\"\r\n" +
@@ -287,6 +288,40 @@ namespace ObjectDumping.Tests
                 "    DateTime: DateTime.MinValue\r\n" +
                 "    NullableDateTime: null\r\n" +
                 "    Enum: DateTimeKind.Unspecified");
+        }
+
+        [Fact(Skip = "Test failed; to be fixed")]
+        public void ShouldDumpGenericClass_WithNestedGenericTypeArguments()
+        {
+            // Arrange
+            var array2D = new string[3, 2]
+            {
+                { "one", "two" },
+                { "three", "four" },
+                { "five", "six" }
+            };
+
+            var array3D = new int[,,]
+            {
+                { { 1, 2, 3 }, { 4, 5, 6 } },
+                { { 7, 8, 9 }, { 10, 11, 12 } }
+            };
+
+            var complexDictionary = new Dictionary<string[,], List<int[,,]>>[1]
+            {
+                new Dictionary<string[,], List<int[,,]>>
+                {
+                    { array2D, new List<int[,,]>{ array3D } }
+                }
+            };
+
+            // Act
+            var dump = ObjectDumperConsole.Dump(complexDictionary);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("???");
         }
 
         [Fact]
@@ -342,7 +377,7 @@ namespace ObjectDumping.Tests
             dump.Should().NotBeNull();
             dump.Should().Be("{RecursivePerson}\r\n");
         }
-        
+
         [Fact]
         public void ShouldDumpRecursiveTypes_RuntimeProperties()
         {
@@ -488,6 +523,26 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
             dump.Should().Be("\"aaa\"\r\n\"bbb\"");
+        }
+
+        [Fact(Skip = "to be implemented")]
+        public void ShouldDumpArray_TwoDimensional()
+        {
+            // Arrange
+            var array = new int[3, 2]
+            {
+                {1, 2},
+                {3, 4},
+                {5, 6}
+            };
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(array);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("???");
         }
 
         [Fact]

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -26,7 +26,7 @@ namespace ObjectDumping.Tests
         public void ShouldDumpObject()
         {
             // Arrange
-            var person = PersonFactory.GetPersonThomas();
+            var person = PersonFactory.GeneratePersons(count: 1).Single();
 
             // Act
             var dump = ObjectDumperConsole.Dump(person);
@@ -34,10 +34,31 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.Person}\r\n  Name: \"Thomas\"\r\n  Char: \r\n  Age: 30\r\n  GetOnly: 11\r\n  Bool: False\r\n  Byte: 0\r\n  ByteArray: ...\r\n    1\r\n    2\r\n    3\r\n    4\r\n  SByte: 0\r\n  Float: 0\r\n  Uint: 0\r\n  Long: 0\r\n  ULong: 0\r\n  Short: 0\r\n  UShort: 0\r\n  Decimal: 0\r\n  Double: 0\r\n  DateTime: 01.01.0001 00:00:00\r\n  NullableDateTime: null\r\n  Enum: Unspecified\r\n");
+            dump.Should().Be(
+                "{Person}\r\n" +
+                "  Name: \"Person 1\"\r\n" +
+                "  Char: ''\r\n" +
+                "  Age: 2\r\n" +
+                "  GetOnly: 11\r\n" +
+                "  Bool: false\r\n" +
+                "  Byte: 0\r\n" +
+                "  ByteArray: ...\r\n" +
+                "    1\r\n    2\r\n    3\r\n    4\r\n" +
+                "  SByte: 0\r\n" +
+                "  Float: 0\r\n" +
+                "  Uint: 0\r\n" +
+                "  Long: 0\r\n" +
+                "  ULong: 0\r\n" +
+                "  Short: 0\r\n" +
+                "  UShort: 0\r\n" +
+                "  Decimal: 0\r\n" +
+                "  Double: 0\r\n" +
+                "  DateTime: DateTime.MinValue\r\n" +
+                "  NullableDateTime: null\r\n" +
+                "  Enum: DateTimeKind.Unspecified");
         }
 
-        [Fact]
+        [Fact(Skip = "Dumping fields is no longer supported; at least for now")]
         public void ShouldDumpObject_WithNullFieldsAndProperties()
         {
             // Arrange
@@ -62,7 +83,8 @@ namespace ObjectDumping.Tests
         public void ShouldDumpObject_WithDumpOptions()
         {
             // Arrange
-            var person = PersonFactory.GetPersonThomas();
+            var person = PersonFactory.GeneratePersons(count: 1).Single();
+
             var options = new DumpOptions
             {
                 IndentChar = '\t',
@@ -76,7 +98,26 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.Person}\r\n	Name: \"Thomas\"\r\n	Char: \r\n	Age: 30\r\n	Bool: False\r\n	Byte: 0\r\n	ByteArray: ...\r\n		1\r\n		2\r\n		3\r\n		4\r\n	SByte: 0\r\n	Float: 0\r\n	Uint: 0\r\n	Long: 0\r\n	ULong: 0\r\n	Short: 0\r\n	UShort: 0\r\n	Decimal: 0\r\n	Double: 0\r\n	DateTime: 01.01.0001 00:00:00\r\n	NullableDateTime: null\r\n	Enum: Unspecified\r\n");
+            dump.Should().Be("{Person}\r\n" +
+                "	Name: \"Person 1\"\r\n" +
+                "	Char: ''\r\n" +
+                "	Age: 2\r\n" +
+                "	Bool: false\r\n" +
+                "	Byte: 0\r\n	ByteArray: ...\r\n" +
+                "		1\r\n" +
+                "		2\r\n" +
+                "		3\r\n" +
+                "		4\r\n" +
+                "	SByte: 0\r\n" +
+                "	Float: 0\r\n" +
+                "	Uint: 0\r\n" +
+                "	Long: 0\r\n	ULong: 0\r\n" +
+                "	Short: 0\r\n" +
+                "	UShort: 0\r\n" +
+                "	Decimal: 0\r\n" +
+                "	Double: 0\r\n	DateTime: DateTime.MinValue\r\n" +
+                "	NullableDateTime: null\r\n" +
+                "	Enum: DateTimeKind.Unspecified");
         }
 
         [Fact]
@@ -91,7 +132,49 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.Person}\r\n  Name: \"Person 1\"\r\n  Char: \r\n  Age: 3\r\n  GetOnly: 11\r\n  Bool: False\r\n  Byte: 0\r\n  ByteArray: ...\r\n    1\r\n    2\r\n    3\r\n    4\r\n  SByte: 0\r\n  Float: 0\r\n  Uint: 0\r\n  Long: 0\r\n  ULong: 0\r\n  Short: 0\r\n  UShort: 0\r\n  Decimal: 0\r\n  Double: 0\r\n  DateTime: 01.01.0001 00:00:00\r\n  NullableDateTime: null\r\n  Enum: Unspecified\r\n\r\n{ObjectDumping.Tests.Testdata.Person}\r\n  Name: \"Person 2\"\r\n  Char: \r\n  Age: 3\r\n  GetOnly: 11\r\n  Bool: False\r\n  Byte: 0\r\n  ByteArray: ...\r\n    1\r\n    2\r\n    3\r\n    4\r\n  SByte: 0\r\n  Float: 0\r\n  Uint: 0\r\n  Long: 0\r\n  ULong: 0\r\n  Short: 0\r\n  UShort: 0\r\n  Decimal: 0\r\n  Double: 0\r\n  DateTime: 01.01.0001 00:00:00\r\n  NullableDateTime: null\r\n  Enum: Unspecified\r\n\r\n");
+            dump.Should().Be(
+                "{Person}\r\n" +
+                "  Name: \"Person 1\"\r\n" +
+                "  Char: ''\r\n" +
+                "  Age: 3\r\n" +
+                "  GetOnly: 11\r\n" +
+                "  Bool: false\r\n" +
+                "  Byte: 0\r\n" +
+                "  ByteArray: ...\r\n" +
+                "    1\r\n    2\r\n    3\r\n    4\r\n" +
+                "  SByte: 0\r\n" +
+                "  Float: 0\r\n" +
+                "  Uint: 0\r\n" +
+                "  Long: 0\r\n" +
+                "  ULong: 0\r\n" +
+                "  Short: 0\r\n" +
+                "  UShort: 0\r\n" +
+                "  Decimal: 0\r\n" +
+                "  Double: 0\r\n" +
+                "  DateTime: DateTime.MinValue\r\n" +
+                "  NullableDateTime: null\r\n" +
+                "  Enum: DateTimeKind.Unspecified\r\n" +
+                "{Person}\r\n" +
+                "  Name: \"Person 2\"\r\n" +
+                "  Char: ''\r\n" +
+                "  Age: 3\r\n" +
+                "  GetOnly: 11\r\n" +
+                "  Bool: false\r\n" +
+                "  Byte: 0\r\n" +
+                "  ByteArray: ...\r\n" +
+                "    1\r\n    2\r\n    3\r\n    4\r\n" +
+                "  SByte: 0\r\n" +
+                "  Float: 0\r\n" +
+                "  Uint: 0\r\n" +
+                "  Long: 0\r\n" +
+                "  ULong: 0\r\n" +
+                "  Short: 0\r\n" +
+                "  UShort: 0\r\n" +
+                "  Decimal: 0\r\n" +
+                "  Double: 0\r\n" +
+                "  DateTime: DateTime.MinValue\r\n" +
+                "  NullableDateTime: null\r\n" +
+                "  Enum: DateTimeKind.Unspecified");
         }
 
         [Fact]
@@ -108,14 +191,66 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
 
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.Organization}\r\n  Name: \"superdev gmbh\"\r\n  Persons: ...\r\n    {ObjectDumping.Tests.Testdata.Person}\r\n      Name: \"Person 1\"\r\n      Char: \r\n      Age: 3\r\n      GetOnly: 11\r\n      Bool: False\r\n      Byte: 0\r\n      ByteArray: ...\r\n        1\r\n        2\r\n        3\r\n        4\r\n      SByte: 0\r\n      Float: 0\r\n      Uint: 0\r\n      Long: 0\r\n      ULong: 0\r\n      Short: 0\r\n      UShort: 0\r\n      Decimal: 0\r\n      Double: 0\r\n      DateTime: 01.01.0001 00:00:00\r\n      NullableDateTime: null\r\n      Enum: Unspecified\r\n\r\n    {ObjectDumping.Tests.Testdata.Person}\r\n      Name: \"Person 2\"\r\n      Char: \r\n      Age: 3\r\n      GetOnly: 11\r\n      Bool: False\r\n      Byte: 0\r\n      ByteArray: ...\r\n        1\r\n        2\r\n        3\r\n        4\r\n      SByte: 0\r\n      Float: 0\r\n      Uint: 0\r\n      Long: 0\r\n      ULong: 0\r\n      Short: 0\r\n      UShort: 0\r\n      Decimal: 0\r\n      Double: 0\r\n      DateTime: 01.01.0001 00:00:00\r\n      NullableDateTime: null\r\n      Enum: Unspecified\r\n\r\n");
+            dump.Should().Be(
+                "{Organization}\r\n" +
+                "  Name: \"superdev gmbh\"\r\n" +
+                "  Persons: ...\r\n" +
+                "    {Person}\r\n" +
+                "      Name: \"Person 1\"\r\n" +
+                "      Char: ''\r\n" +
+                "      Age: 3\r\n" +
+                "      GetOnly: 11\r\n" +
+                "      Bool: false\r\n" +
+                "      Byte: 0\r\n" +
+                "      ByteArray: ...\r\n" +
+                "        1\r\n" +
+                "        2\r\n" +
+                "        3\r\n" +
+                "        4\r\n" +
+                "      SByte: 0\r\n" +
+                "      Float: 0\r\n" +
+                "      Uint: 0\r\n" +
+                "      Long: 0\r\n" +
+                "      ULong: 0\r\n" +
+                "      Short: 0\r\n" +
+                "      UShort: 0\r\n" +
+                "      Decimal: 0\r\n" +
+                "      Double: 0\r\n" +
+                "      DateTime: DateTime.MinValue\r\n" +
+                "      NullableDateTime: null\r\n" +
+                "      Enum: DateTimeKind.Unspecified\r\n" +
+                "    {Person}\r\n" +
+                "      Name: \"Person 2\"\r\n" +
+                "      Char: ''\r\n" +
+                "      Age: 3\r\n" +
+                "      GetOnly: 11\r\n" +
+                "      Bool: false\r\n" +
+                "      Byte: 0\r\n" +
+                "      ByteArray: ...\r\n" +
+                "        1\r\n" +
+                "        2\r\n" +
+                "        3\r\n" +
+                "        4\r\n" +
+                "      SByte: 0\r\n" +
+                "      Float: 0\r\n" +
+                "      Uint: 0\r\n" +
+                "      Long: 0\r\n" +
+                "      ULong: 0\r\n" +
+                "      Short: 0\r\n" +
+                "      UShort: 0\r\n" +
+                "      Decimal: 0\r\n" +
+                "      Double: 0\r\n" +
+                "      DateTime: DateTime.MinValue\r\n" +
+                "      NullableDateTime: null\r\n" +
+                "      Enum: DateTimeKind.Unspecified\r\n" +
+                "  IsAfterCollection: true");
         }
 
         [Fact]
         public void ShouldDumpMultipleGenericTypes()
         {
             // Arrange
-            var person = PersonFactory.GeneratePersons(count: 1).First();
+            var person = PersonFactory.GeneratePersons(count: 1).Single();
             var genericClass = new GenericClass<string, float, Person> { Prop1 = "Test", Prop2 = 123.45f, Prop3 = person };
 
             // Act
@@ -124,7 +259,34 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.GenericClass<System.String, System.Single, ObjectDumping.Tests.Testdata.Person>}\r\n  Prop1: \"Test\"\r\n  Prop2: 123.45\r\n  Prop3: { }\r\n    {ObjectDumping.Tests.Testdata.Person}\r\n      Name: \"Person 1\"\r\n      Char: \r\n      Age: 2\r\n      GetOnly: 11\r\n      Bool: False\r\n      Byte: 0\r\n      ByteArray: ...\r\n        1\r\n        2\r\n        3\r\n        4\r\n      SByte: 0\r\n      Float: 0\r\n      Uint: 0\r\n      Long: 0\r\n      ULong: 0\r\n      Short: 0\r\n      UShort: 0\r\n      Decimal: 0\r\n      Double: 0\r\n      DateTime: 01.01.0001 00:00:00\r\n      NullableDateTime: null\r\n      Enum: Unspecified\r\n");
+            dump.Should().Be(
+                "{GenericClass<String, Single, Person>}\r\n" +
+                "  Prop1: \"Test\"\r\n" +
+                "  Prop2: 123.45\r\n" +
+                "  Prop3: {Person}\r\n" +
+                "    Name: \"Person 1\"\r\n" +
+                "    Char: ''\r\n" +
+                "    Age: 2\r\n" +
+                "    GetOnly: 11\r\n" +
+                "    Bool: false\r\n" +
+                "    Byte: 0\r\n" +
+                "    ByteArray: ...\r\n" +
+                "      1\r\n" +
+                "      2\r\n" +
+                "      3\r\n" +
+                "      4\r\n" +
+                "    SByte: 0\r\n" +
+                "    Float: 0\r\n" +
+                "    Uint: 0\r\n" +
+                "    Long: 0\r\n" +
+                "    ULong: 0\r\n" +
+                "    Short: 0\r\n" +
+                "    UShort: 0\r\n" +
+                "    Decimal: 0\r\n" +
+                "    Double: 0\r\n" +
+                "    DateTime: DateTime.MinValue\r\n" +
+                "    NullableDateTime: null\r\n" +
+                "    Enum: DateTimeKind.Unspecified");
         }
 
         [Fact]
@@ -142,7 +304,11 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
 
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.Organization}\r\n  Name: \"superdev gmbh\"\r\n  Persons: ...\r\n");
+            dump.Should().Be(
+                "{Organization}\r\n" +
+                "  Name: \"superdev gmbh\"\r\n" +
+                "  Persons: ...\r\n" +
+                "  IsAfterCollection: true");
         }
 
         // TODO: Bug in dumping random structs
@@ -174,14 +340,14 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.RecursivePerson}\r\n  Parent: { }\r\n    {ObjectDumping.Tests.Testdata.RecursivePerson} <-- bidirectional reference found\r\n");
+            dump.Should().Be("{RecursivePerson}\r\n");
         }
         
         [Fact]
         public void ShouldDumpRecursiveTypes_RuntimeProperties()
         {
             // Arrange
-            var person = PersonFactory.GeneratePersons(count: 1).First();
+            var person = PersonFactory.GeneratePersons(count: 1).Single();
             var properties = person.GetType().GetRuntimeProperties();
             var options = new DumpOptions { MaxLevel = 2 };
 
@@ -191,7 +357,6 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Contain("<-- bidirectional reference found");
         }
 
         [Fact]
@@ -208,7 +373,7 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
 
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.TestObject}\r\n  NullableDateTime: null\r\n");
+            dump.Should().Be("{TestObject}\r\n  NullableDateTime: null");
         }
 
         [Fact]
@@ -225,7 +390,7 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
 
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.OrderPropertyTestObject}\r\n  A: null\r\n  B: null\r\n  C: null\r\n");
+            dump.Should().Be("{OrderPropertyTestObject}\r\n  A: null\r\n  B: null\r\n  C: null");
         }
 
         [Fact]
@@ -272,7 +437,7 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("Utc");
+            dump.Should().Be("DateTimeKind.Utc");
         }
 
         [Fact]
@@ -287,7 +452,7 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("024cc229-dea0-4d7a-9fc8-722e3a0c69a3");
+            dump.Should().Be("{024cc229-dea0-4d7a-9fc8-722e3a0c69a3}");
         }
 
         [Fact]
@@ -307,7 +472,22 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("[1, Value1]\r\n[2, Value2]\r\n[3, Value3]\r\n");
+            dump.Should().Be("{ 1, \"Value1\" }\r\n{ 2, \"Value2\" }\r\n{ 3, \"Value3\" }");
+        }
+
+        [Fact]
+        public void ShouldDumpArray_OneDimensional()
+        {
+            // Arrange
+            var array = new string[] { "aaa", "bbb" };
+
+            // Act
+            var dump = ObjectDumperConsole.Dump(array);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("\"aaa\"\r\n\"bbb\"");
         }
 
         [Fact]
@@ -344,9 +524,7 @@ namespace ObjectDumping.Tests
 
             // Assert
             this.testOutputHelper.WriteLine(dump);
-            dump.Should().NotBeNull();
-            dump.Should().Contain("Name: \"de-CH\"");
-            dump.Should().Contain("EnglishName: \"German (Switzerland)\"");
+            dump.Should().Be("de-CH");
         }
     }
 }

--- a/Tests/ObjectDumper.Tests/ObjectDumperTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using ObjectDumping.Tests.Testdata;
 using ObjectDumping.Tests.Utils;
@@ -20,7 +21,7 @@ namespace ObjectDumping.Tests
         public void ShouldDumpObject_WithDefaultDumpOptions()
         {
             // Arrange
-            var person = PersonFactory.GetPersonThomas();
+            var person = PersonFactory.GeneratePersons(count: 1).Single();
 
             // Act
             var dump = ObjectDumper.Dump(person);
@@ -28,7 +29,28 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{ObjectDumping.Tests.Testdata.Person}\r\n  Name: \"Thomas\"\r\n  Char: \r\n  Age: 30\r\n  GetOnly: 11\r\n  Bool: False\r\n  Byte: 0\r\n  ByteArray: ...\r\n    1\r\n    2\r\n    3\r\n    4\r\n  SByte: 0\r\n  Float: 0\r\n  Uint: 0\r\n  Long: 0\r\n  ULong: 0\r\n  Short: 0\r\n  UShort: 0\r\n  Decimal: 0\r\n  Double: 0\r\n  DateTime: 01.01.0001 00:00:00\r\n  NullableDateTime: null\r\n  Enum: Unspecified\r\n");
+            dump.Should().Be(
+                "{Person}\r\n" +
+                "  Name: \"Person 1\"\r\n" +
+                "  Char: ''\r\n" +
+                "  Age: 2\r\n" +
+                "  GetOnly: 11\r\n" +
+                "  Bool: false\r\n" +
+                "  Byte: 0\r\n" +
+                "  ByteArray: ...\r\n" +
+                "    1\r\n    2\r\n    3\r\n    4\r\n" +
+                "  SByte: 0\r\n" +
+                "  Float: 0\r\n" +
+                "  Uint: 0\r\n" +
+                "  Long: 0\r\n" +
+                "  ULong: 0\r\n" +
+                "  Short: 0\r\n" +
+                "  UShort: 0\r\n" +
+                "  Decimal: 0\r\n" +
+                "  Double: 0\r\n" +
+                "  DateTime: DateTime.MinValue\r\n" +
+                "  NullableDateTime: null\r\n" +
+                "  Enum: DateTimeKind.Unspecified");
         }
 
         [Fact]

--- a/Tests/ObjectDumper.Tests/Testdata/Organization.cs
+++ b/Tests/ObjectDumper.Tests/Testdata/Organization.cs
@@ -12,5 +12,7 @@ namespace ObjectDumping.Tests.Testdata
         public string Name { get; set; }
 
         public ICollection<Person> Persons { get; set; }
+
+        public bool IsAfterCollection { get; set; } = true;
     }
 }

--- a/build.yml
+++ b/build.yml
@@ -1,10 +1,10 @@
 ####################################################################
 # VSTS Build Configuration, Version 1.3
 #
-# (c)2019 superdev GmbH
+# (c)2020 superdev GmbH
 ####################################################################
 
-name: 2.5.$(date:yy)$(DayOfYear).$(rev:rr)
+name: 3.0.$(date:yy)$(DayOfYear).$(rev:rr)
 
 pool:
   vmImage: 'windows-2019'
@@ -42,9 +42,9 @@ steps:
     FileVersionNumber: '$(Build.BuildNumber)'
 
 - task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 5.5.1'
+  displayName: 'Use NuGet 5.x'
   inputs:
-    versionSpec: 5.5.1
+    versionSpec: 5.x
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'


### PR DESCRIPTION
Meanwhile, there are some differences in the object dumping logic of ObjectDumperConsole and ObjectDumperCSharp which makes it hard to maintain and extend both classes. This PR tries to harmonize both code bases to have similar logic in both dumpers.