### PR TITLE
Dump ValueTuples<>

### DIFF
--- a/ObjectDumper/Internal/DumperBase.cs
+++ b/ObjectDumper/Internal/DumperBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace ObjectDumping.Internal
@@ -19,6 +20,8 @@ namespace ObjectDumping.Internal
             this.hashListOfFoundElements = new List<int>();
             this.isNewLine = true;
         }
+
+        protected abstract void FormatValue(object o, int intentLevel);
 
         public int Level
         {
@@ -132,5 +135,37 @@ namespace ObjectDumping.Internal
             var className = type.GetFormattedName(this.DumpOptions.UseTypeFullName);
             return className;
         }
+
+#if NETSTANDARD_2
+        public static bool IsValueTuple(Type type)
+        {
+            return
+                type.IsValueType &&
+                type.IsGenericType &&
+                type.FullName is string fullName &&
+                (fullName.StartsWith("System.ValueTuple") || fullName.StartsWith("System.ValueTuple`"));
+        }
+
+        protected void WriteValueTuple(object o, Type type)
+        {
+            var fields = type.GetFields().ToList();
+            if (fields.Any())
+            {
+                var last = fields.LastOrDefault();
+
+                this.Write("(");
+                foreach (var field in fields)
+                {
+                    var fieldValue = field.GetValue(o);
+                    FormatValue(fieldValue, 0);
+                    if (!Equals(field, last))
+                    {
+                        this.Write(", ");
+                    }
+                }
+                this.Write(")");
+            }
+        }
+#endif
     }
 }

--- a/ObjectDumper/Internal/DumperBase.cs
+++ b/ObjectDumper/Internal/DumperBase.cs
@@ -128,44 +128,5 @@ namespace ObjectDumping.Internal
         {
             return this.stringBuilder.ToString();
         }
-
-        public string GetClassName(object o)
-        {
-            var type = o.GetType();
-            var className = type.GetFormattedName(this.DumpOptions.UseTypeFullName);
-            return className;
-        }
-
-#if NETSTANDARD_2
-        public static bool IsValueTuple(Type type)
-        {
-            return
-                type.IsValueType &&
-                type.IsGenericType &&
-                type.FullName is string fullName &&
-                (fullName.StartsWith("System.ValueTuple") || fullName.StartsWith("System.ValueTuple`"));
-        }
-
-        protected void WriteValueTuple(object o, Type type)
-        {
-            var fields = type.GetFields().ToList();
-            if (fields.Any())
-            {
-                var last = fields.LastOrDefault();
-
-                this.Write("(");
-                foreach (var field in fields)
-                {
-                    var fieldValue = field.GetValue(o);
-                    FormatValue(fieldValue, 0);
-                    if (!Equals(field, last))
-                    {
-                        this.Write(", ");
-                    }
-                }
-                this.Write(")");
-            }
-        }
-#endif
     }
 }

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -163,7 +163,7 @@ namespace ObjectDumping.Internal
             }
         }
 
-        private void FormatValue(object o, int intentLevel = 0)
+        protected override void FormatValue(object o, int intentLevel = 0)
         {
             if (this.IsMaxLevel())
             {
@@ -346,6 +346,14 @@ namespace ObjectDumping.Internal
                 this.Write(" }");
                 return;
             }
+
+#if NETSTANDARD_2
+            if (IsValueTuple(type))
+            {
+                WriteValueTuple(o, type);
+                return;
+            }
+#endif
 
             if (o is IEnumerable enumerable)
             {

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -42,7 +42,9 @@ namespace ObjectDumping.Internal
         {
             this.AddAlreadyTouched(o);
 
-            this.Write($"new {GetClassName(o)}", intentLevel);
+            var type = o.GetType();
+
+            this.Write($"new {type.GetFormattedName(this.DumpOptions.UseTypeFullName)}", intentLevel);
             this.LineBreak();
             this.Write("{");
             this.LineBreak();
@@ -348,7 +350,7 @@ namespace ObjectDumping.Internal
             }
 
 #if NETSTANDARD_2
-            if (IsValueTuple(type))
+            if (type.IsValueTuple())
             {
                 WriteValueTuple(o, type);
                 return;
@@ -357,7 +359,7 @@ namespace ObjectDumping.Internal
 
             if (o is IEnumerable enumerable)
             {
-                this.Write($"new {GetClassName(o)}", intentLevel);
+                this.Write($"new {type.GetFormattedName(this.DumpOptions.UseTypeFullName)}", intentLevel);
                 this.LineBreak();
                 this.Write("{");
                 this.LineBreak();
@@ -368,6 +370,33 @@ namespace ObjectDumping.Internal
 
             this.CreateObject(o, intentLevel);
         }
+
+#if NETSTANDARD_2
+        private void WriteValueTuple(object o, Type type)
+        {
+            var fields = type.GetFields().ToList();
+            if (fields.Any())
+            {
+                var last = fields.LastOrDefault();
+
+                this.Write("(");
+                foreach (var field in fields)
+                {
+                    var fieldValue = field.GetValue(o);
+                    this.FormatValue(fieldValue, 0);
+                    if (!Equals(field, last))
+                    {
+                        this.Write(", ");
+                    }
+                }
+                this.Write(")");
+            }
+            else
+            {
+                this.Write("ValueTuple.Create()");
+            }
+        }
+#endif
 
         private void WriteItems(IEnumerable items)
         {
@@ -404,7 +433,9 @@ namespace ObjectDumping.Internal
                 return "x";
             }
 
-            var className = GetClassName(element);
+            var type = element.GetType();
+
+            var className = type.GetFormattedName(useFullName: false, useValueTupleFormatting: false);
             string variableName;
 
             var splitGenerics = className.Split('<');
@@ -421,6 +452,7 @@ namespace ObjectDumping.Internal
                 // are using more sophisticated variable names
                 variableName = className
                     .Replace("Nullable<", "OfNullable")
+                    .Replace("<", "Of")
                     .Replace("<", "Of")
                     .Replace(">", "s")
                     .Replace(" ", "")

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -147,7 +147,7 @@ namespace ObjectDumping.Internal
             }
         }
 
-        private void FormatValue(object o, int intentLevel = 0)
+        protected override void FormatValue(object o, int intentLevel = 0)
         {
             if (this.IsMaxLevel())
             {
@@ -282,6 +282,7 @@ namespace ObjectDumping.Internal
                 this.Write($"{systemType.FullName}", intentLevel);
                 return;
             }
+
             var typeInfo = type.GetTypeInfo();
             if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
             {
@@ -295,6 +296,14 @@ namespace ObjectDumping.Internal
                 this.Write(" }");
                 return;
             }
+
+#if NETSTANDARD_2
+            if (IsValueTuple(type))
+            {
+                WriteValueTuple(o, type);
+                return;
+            }
+#endif
 
             if (o is IEnumerable enumerable)
             {

--- a/ObjectDumper/ObjectDumper.csproj
+++ b/ObjectDumper/ObjectDumper.csproj
@@ -25,6 +25,10 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD_2</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationIcon />
     <OutputType>Library</OutputType>

--- a/Tests/ObjectDumper.Tests/ObjectDumper.Tests.csproj
+++ b/Tests/ObjectDumper.Tests/ObjectDumper.Tests.csproj
@@ -1,30 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
-    <AssemblyName>ObjectDumper.Tests</AssemblyName>
-    <PackageId>ObjectDumper.Tests</PackageId>
-    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <RootNamespace>ObjectDumping.Tests</RootNamespace>
-    <NeutralLanguage>en</NeutralLanguage>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+		<AssemblyName>ObjectDumper.Tests</AssemblyName>
+		<PackageId>ObjectDumper.Tests</PackageId>
+		<RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<RootNamespace>ObjectDumping.Tests</RootNamespace>
+		<NeutralLanguage>en</NeutralLanguage>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+	</PropertyGroup>
 
-  <!-- Include files in the Resources directory to be used across the test suite -->
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\**\*.*" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\ObjectDumper\ObjectDumper.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="5.4.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+		<PackageReference Include="xunit" Version="2.4.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+	</ItemGroup>
+
+	<!-- Include files in the Resources directory to be used across the test suite -->
+	<ItemGroup>
+		<EmbeddedResource Include="Resources\**\*.*" />
+	</ItemGroup>
+	<ItemGroup>
+		<Folder Include="Properties\" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\ObjectDumper\ObjectDumper.csproj" />
+	</ItemGroup>
 </Project>

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -882,7 +882,22 @@ namespace ObjectDumping.Tests
 
 #if NETCORE
         [Fact]
-        public void ShouldDumpValueTuple()
+        public void ShouldDumpValueTuple_Arity0()
+        {
+            // Arrange 
+            var valueTuple = ValueTuple.Create();
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(valueTuple);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("var valueTuple = ValueTuple.Create();");
+        }
+
+        [Fact]
+        public void ShouldDumpValueTuple_Arity3()
         {
             // Arrange 
             var valueTuple = (1, "Bill", "Gates");
@@ -925,7 +940,7 @@ namespace ObjectDumping.Tests
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
             dump.Should().Be(
-                "var list = new List<ValueTuple<String, Int32>>\r\n" +
+                "var list = new List<(String, Int32)>\r\n" +
                 "{\r\n" +
                 "  (\"Person 1\", 3),\r\n" +
                 "  (\"Person 2\", 3)\r\n" +

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -17,7 +17,7 @@ namespace ObjectDumping.Tests
     {
         private readonly ITestOutputHelper testOutputHelper;
 
-        public ObjectDumperCSharpCSharpTests(ITestOutputHelper testOutputHelper)
+        public ObjectDumperCSharpTests(ITestOutputHelper testOutputHelper)
         {
             this.testOutputHelper = testOutputHelper;
         }

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -890,7 +890,6 @@ namespace ObjectDumping.Tests
             // Act
             var dump = ObjectDumperCSharp.Dump(valueTuple);
 
-
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
@@ -905,7 +904,6 @@ namespace ObjectDumping.Tests
 
             // Act
             var dump = ObjectDumperCSharp.Dump(valueTuple);
-
 
             // Assert
             this.testOutputHelper.WriteLine(dump);

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace ObjectDumping.Tests
 {
     [Collection(TestCollections.CultureSpecific)]
-    public class ObjectDumperCSharpCSharpTests
+    public class ObjectDumperCSharpTests
     {
         private readonly ITestOutputHelper testOutputHelper;
 

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -879,5 +879,60 @@ namespace ObjectDumping.Tests
                 "  StatusInformation = \"Test status\"\r\n" +
                 "};");
         }
+
+#if NETCORE
+        [Fact]
+        public void ShouldDumpValueTuple()
+        {
+            // Arrange 
+            var valueTuple = (1, "Bill", "Gates");
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(valueTuple);
+
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("var valueTuple = (1, \"Bill\", \"Gates\");");
+        }
+
+        [Fact]
+        public void ShouldDumpValueTuple_WithDefaultValue()
+        {
+            // Arrange 
+            (int Id, string FirstName, string LastName) valueTuple = default;
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(valueTuple);
+
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("var valueTuple = (0, null, null);");
+        }
+
+        [Fact]
+        public void ShouldDumpEnumerable_ValueTuples()
+        {
+            // Arrange 
+            var persons = PersonFactory.GeneratePersons(count: 2).ToList();
+            var valueTuples = persons.Select(s => (s.Name, s.Age)).ToList();
+
+            // Act
+            var dump = ObjectDumperCSharp.Dump(valueTuples);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be(
+                "var list = new List<ValueTuple<String, Int32>>\r\n" +
+                "{\r\n" +
+                "  (\"Person 1\", 3),\r\n" +
+                "  (\"Person 2\", 3)\r\n" +
+                "};");
+        }
+#endif
     }
 }

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -369,7 +369,7 @@ namespace ObjectDumping.Tests
         //    var dictionaryEntry = new DictionaryEntry { Key = 1, Value = "Value1" };
 
         //    // Act
-        //    var dump = ObjectDumperCSharp.Dump(dictionaryEntry);
+        //    var dump = ObjectDumperConsole.Dump(dictionaryEntry);
 
         //    // Assert
         //    this.testOutputHelper.WriteLine(dump);
@@ -552,7 +552,7 @@ namespace ObjectDumping.Tests
             };
 
             // Act
-            var dump = ObjectDumperCSharp.Dump(array);
+            var dump = ObjectDumperConsole.Dump(array);
 
             // Assert
             this.testOutputHelper.WriteLine(dump);
@@ -618,5 +618,58 @@ namespace ObjectDumping.Tests
                 "  Status: X509ChainStatusFlags.NoError\r\n" +
                 "  StatusInformation: \"Test status\"");
         }
+
+
+#if NETCORE
+        [Fact]
+        public void ShouldDumpValueTuple()
+        {
+            // Arrange 
+            var valueTuple = (1, "Bill", "Gates");
+
+            // Act
+            var dump = ObjectDumperConsole.Dump(valueTuple);
+
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("(1, \"Bill\", \"Gates\")");
+        }
+
+        [Fact]
+        public void ShouldDumpValueTuple_WithDefaultValue()
+        {
+            // Arrange 
+            (int Id, string FirstName, string LastName) valueTuple = default;
+
+            // Act
+            var dump = ObjectDumperConsole.Dump(valueTuple);
+
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("(0, null, null)");
+        }
+
+        [Fact]
+        public void ShouldDumpEnumerable_ValueTuples()
+        {
+            // Arrange 
+            var persons = PersonFactory.GeneratePersons(count: 2).ToList();
+            var valueTuples = persons.Select(s => (s.Name, s.Age)).ToList();
+
+            // Act
+            var dump = ObjectDumperConsole.Dump(valueTuples);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be(
+                "(\"Person 1\", 3)\r\n" +
+                "(\"Person 2\", 3)");
+        }
+#endif
     }
 }

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -630,7 +630,6 @@ namespace ObjectDumping.Tests
             // Act
             var dump = ObjectDumperConsole.Dump(valueTuple);
 
-
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
@@ -645,7 +644,6 @@ namespace ObjectDumping.Tests
 
             // Act
             var dump = ObjectDumperConsole.Dump(valueTuple);
-
 
             // Assert
             this.testOutputHelper.WriteLine(dump);

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -622,7 +622,22 @@ namespace ObjectDumping.Tests
 
 #if NETCORE
         [Fact]
-        public void ShouldDumpValueTuple()
+        public void ShouldDumpValueTuple_Arity0()
+        {
+            // Arrange 
+            var valueTuple = ValueTuple.Create();
+
+            // Act
+            var dump = ObjectDumperConsole.Dump(valueTuple);
+
+            // Assert
+            this.testOutputHelper.WriteLine(dump);
+            dump.Should().NotBeNull();
+            dump.Should().Be("()");
+        }
+
+        [Fact]
+        public void ShouldDumpValueTuple_Arity3()
         {
             // Arrange 
             var valueTuple = (1, "Bill", "Gates");


### PR DESCRIPTION
Support for dumping ValueTuples. This feature is only supported if .Net Standard 2.0 or higher is used.