### PR TITLE
Allow dumper to throw exceptions.

### DIFF
--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -43,6 +43,11 @@ public class DumpOptions
     public Expression<Func<PropertyInfo, object>> PropertyOrderBy { get; set; }
 
     /// <summary>
+    /// Will throw the exception rather than swallow and list it on the property.  Default is catch and swallow.
+    /// </summary>
+    public bool ThrowExceptions { get; set; }
+
+    /// <summary>
     /// Ignores default values if set to <c>true</c>.
     /// Default: <c>false</c>
     /// </summary>

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -91,7 +91,7 @@ namespace ObjectDumping.Internal
 
             foreach (var property in properties)
             {
-                var value = property.TryGetValue(o);
+                var value = property.TryGetValue(o, this.DumpOptions.ThrowExceptions);
 
                 if (this.AlreadyTouched(value))
                 {

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -78,7 +78,7 @@ namespace ObjectDumping.Internal
 
             foreach (var property in properties)
             {
-                var value = property.TryGetValue(o);
+                var value = property.TryGetValue(o, this.DumpOptions.ThrowExceptions);
 
                 if (this.AlreadyTouched(value))
                 {

--- a/ObjectDumper/Internal/PropertyInfoExtensions.cs
+++ b/ObjectDumper/Internal/PropertyInfoExtensions.cs
@@ -5,7 +5,7 @@ namespace ObjectDumping.Internal
 {
     internal static class PropertyInfoExtensions
     {
-        internal static object TryGetValue(this PropertyInfo property, object element)
+        internal static object TryGetValue(this PropertyInfo property, object element, bool throwException)
         {
             object value;
             try
@@ -14,6 +14,8 @@ namespace ObjectDumping.Internal
             }
             catch (Exception ex)
             {
+                if (throwException)
+                    throw;
                 value = $"{{{ex.Message}}}";
             }
 

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -501,6 +501,29 @@ namespace ObjectDumping.Tests
         }
 
         [Fact]
+        public void ShouldThrowException()
+        {
+            // Arrange
+            var thrownException = new Exception();
+            var testObject = new TestObjectWithException()
+            {
+                Exception = thrownException,
+            };
+            var options = new DumpOptions() { ThrowExceptions = true, };
+
+            try
+            {
+                // Act
+                var dump = ObjectDumperCSharp.Dump(testObject, options);
+            }
+            catch (Exception ex)
+            {
+                // Assert
+                Assert.Equal(ex.InnerException, thrownException);
+            }
+        }
+
+        [Fact]
         public void ShouldOrderProperties()
         {
             // Arrange

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -585,6 +585,29 @@ namespace ObjectDumping.Tests
         }
 
         [Fact]
+        public void ShouldThrowException()
+        {
+            // Arrange
+            var thrownException = new Exception();
+            var testObject = new TestObjectWithException()
+            {
+                Exception = thrownException,
+            };
+            var options = new DumpOptions() { ThrowExceptions = true, };
+
+            try
+            {
+                // Act
+                var dump = ObjectDumperConsole.Dump(testObject, options);
+            }
+            catch (Exception ex)
+            {
+                // Assert
+                Assert.Equal(ex.InnerException, thrownException);
+            }
+        }
+
+        [Fact]
         public void ShouldOrderProperties()
         {
             // Arrange

--- a/Tests/ObjectDumper.Tests/Testdata/TestObjectWithException.cs
+++ b/Tests/ObjectDumper.Tests/Testdata/TestObjectWithException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ObjectDumping.Tests.Testdata
+{
+    public class TestObjectWithException
+    {
+        private Exception _ex;
+
+        public Exception Exception { get => throw _ex; set => _ex = value; }
+    }
+}


### PR DESCRIPTION
Added ThrowException to the DumpOptions.
Modified Console and CSharp dumper to pass the parameter
Added throw bool to PropertyInfoExtensions
Check options before either throwing or listing exception.
Added tests to both Console and CSharp dumper.