### PR TITLE
Add member renamer

### DIFF
--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -42,6 +42,8 @@ public class DumpOptions
 
     public Expression<Func<PropertyInfo, object>> PropertyOrderBy { get; set; }
 
+    public Func<string, string> MemberRenamer { get; set; }
+
     /// <summary>
     /// Ignores default values if set to <c>true</c>.
     /// Default: <c>false</c>

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -42,6 +42,9 @@ public class DumpOptions
 
     public Expression<Func<PropertyInfo, object>> PropertyOrderBy { get; set; }
 
+    /// <summary>
+    /// Allows to rename properties and fields before they are dumped.
+    /// </summary>
     public Func<string, string> MemberRenamer { get; set; }
 
     /// <summary>

--- a/ObjectDumper/Internal/DumperBase.cs
+++ b/ObjectDumper/Internal/DumperBase.cs
@@ -120,6 +120,16 @@ namespace ObjectDumping.Internal
             return false;
         }
 
+        protected string ResolvePropertyName(string name)
+        {
+            if (this.DumpOptions.MemberRenamer is Func<string, string> memberRenamer)
+            {
+                return memberRenamer.Invoke(name);
+            }
+
+            return name;
+        }
+
         private static int GenerateHashCode(object value)
         {
             return HashCode.Combine(value, value.GetType());

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -584,11 +584,6 @@ namespace ObjectDumping.Internal
             this.Level--;
         }
 
-        private string ResolvePropertyName(string propertyName)
-        {
-            return this.DumpOptions.MemberRenamer?.Invoke(propertyName) ?? propertyName;
-        }
-
         private string GetVariableName(object element)
         {
             if (element == null)

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -584,9 +584,9 @@ namespace ObjectDumping.Internal
             this.Level--;
         }
 
-        private string ResolvePropertyName(string name)
+        private string ResolvePropertyName(string propertyName)
         {
-            return this.DumpOptions.MemberRenamer != null ? this.DumpOptions.MemberRenamer.Invoke(name) : name;
+            return this.DumpOptions.MemberRenamer?.Invoke(propertyName) ?? propertyName;
         }
 
         private string GetVariableName(object element)

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -16,11 +16,6 @@ namespace ObjectDumping.Internal
         {
         }
 
-        private string ResolvePropertyName(string name)
-        {
-            return this.DumpOptions.MemberRenamer != null ? this.DumpOptions.MemberRenamer.Invoke(name) : name;
-        }
-
         public static string Dump(object element, DumpOptions dumpOptions = null)
         {
             if (dumpOptions == null)
@@ -587,6 +582,11 @@ namespace ObjectDumping.Internal
             }
 
             this.Level--;
+        }
+
+        private string ResolvePropertyName(string name)
+        {
+            return this.DumpOptions.MemberRenamer != null ? this.DumpOptions.MemberRenamer.Invoke(name) : name;
         }
 
         private string GetVariableName(object element)

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -16,6 +16,11 @@ namespace ObjectDumping.Internal
         {
         }
 
+        private string ResolvePropertyName(string name)
+        {
+            return this.DumpOptions.MemberRenamer != null ? this.DumpOptions.MemberRenamer.Invoke(name) : name;
+        }
+
         public static string Dump(object element, DumpOptions dumpOptions = null)
         {
             if (dumpOptions == null)
@@ -103,7 +108,7 @@ namespace ObjectDumping.Internal
 
                 if (this.AlreadyTouched(value))
                 {
-                    this.Write($"{propertiesAndValue.Property.Name} = ");
+                    this.Write($"{this.ResolvePropertyName(propertiesAndValue.Property.Name)} = ");
                     this.FormatValue(propertiesAndValue.DefaultValue);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {
@@ -132,7 +137,7 @@ namespace ObjectDumping.Internal
                 }
                 else
                 {
-                    this.Write($"{propertiesAndValue.Property.Name} = ");
+                    this.Write($"{this.ResolvePropertyName(propertiesAndValue.Property.Name)} = ");
                     this.FormatValue(value);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -27,6 +27,11 @@ namespace ObjectDumping.Internal
             return instance.ToString();
         }
 
+        private string ResolvePropertyName(string name)
+        {
+            return this.DumpOptions.MemberRenamer != null ? this.DumpOptions.MemberRenamer.Invoke(name) : name;
+        }
+
         private void CreateObject(object o, int intentLevel = 0)
         {
             this.AddAlreadyTouched(o);
@@ -81,7 +86,7 @@ namespace ObjectDumping.Internal
 
                 if (this.AlreadyTouched(value))
                 {
-                    this.Write($"{propertiesAndValue.Property.Name}: ");
+                    this.Write($"{this.ResolvePropertyName(propertiesAndValue.Property.Name)}: ");
                     this.FormatValue(propertiesAndValue.DefaultValue);
                     this.Write(" --> Circular reference detected");
                     if (!Equals(propertiesAndValue, lastProperty))
@@ -109,7 +114,7 @@ namespace ObjectDumping.Internal
                 }
                 else
                 {
-                    this.Write($"{propertiesAndValue.Property.Name}: ");
+                    this.Write($"{this.ResolvePropertyName(propertiesAndValue.Property.Name)}: ");
                     this.FormatValue(value);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -27,11 +27,6 @@ namespace ObjectDumping.Internal
             return instance.ToString();
         }
 
-        private string ResolvePropertyName(string name)
-        {
-            return this.DumpOptions.MemberRenamer != null ? this.DumpOptions.MemberRenamer.Invoke(name) : name;
-        }
-
         private void CreateObject(object o, int intentLevel = 0)
         {
             this.AddAlreadyTouched(o);

--- a/ObjectDumper/ObjectDumper.csproj
+++ b/ObjectDumper/ObjectDumper.csproj
@@ -100,7 +100,7 @@
       
 1.0.0
 - Initial release</PackageReleaseNotes>
-    <Copyright>Copyright 2021</Copyright>
+    <Copyright>Copyright 2022</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ C# Escape / Unescape
 https://codebeautify.org/csharp-escape-unescape
 
 ### License
-This project is Copyright &copy; 2021 [Thomas Galliker](https://ch.linkedin.com/in/thomasgalliker). Free for non-commercial use. For commercial use please contact the author.
+This project is Copyright &copy; 2022 [Thomas Galliker](https://ch.linkedin.com/in/thomasgalliker). Free for non-commercial use. For commercial use please contact the author.

--- a/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperCSharpTests.cs
@@ -133,7 +133,8 @@ namespace ObjectDumping.Tests
                 IndentSize = 1,
                 IndentChar = '\t',
                 LineBreakChar = "\n",
-                SetPropertiesOnly = true
+                SetPropertiesOnly = true,
+                MemberRenamer = m => m == "Name" ? "RenamedName" : m,
             };
 
             // Act
@@ -142,7 +143,32 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("var person = new Person\n{\n	Name = \"Thomas\",\n	Char = '',\n	Age = 30,\n	Bool = false,\n	Byte = 0,\n	ByteArray = new byte[]\n	{\n		1,\n		2,\n		3,\n		4\n	},\n	SByte = 0,\n	Float = 0f,\n	Uint = 0u,\n	Long = 0L,\n	ULong = 0UL,\n	Short = 0,\n	UShort = 0,\n	Decimal = 0m,\n	Double = 0d,\n	DateTime = DateTime.MinValue,\n	NullableDateTime = null,\n	Enum = DateTimeKind.Unspecified\n};");
+            dump.Should().Be("var person = new Person\n" +
+                "{\n" +
+                "	RenamedName = \"Thomas\",\n" +
+                "	Char = '',\n" +
+                "	Age = 30,\n" +
+                "	Bool = false,\n" +
+                "	Byte = 0,\n" +
+                "	ByteArray = new byte[]\n" +
+                "	{\n" +
+                "		1,\n" +
+                "		2,\n" +
+                "		3,\n		4\n" +
+                "	},\n" +
+                "	SByte = 0,\n" +
+                "	Float = 0f,\n" +
+                "	Uint = 0u,\n" +
+                "	Long = 0L,\n" +
+                "	ULong = 0UL,\n" +
+                "	Short = 0,\n" +
+                "	UShort = 0,\n" +
+                "	Decimal = 0m,\n" +
+                "	Double = 0d,\n" +
+                "	DateTime = DateTime.MinValue,\n" +
+                "	NullableDateTime = null,\n" +
+                "	Enum = DateTimeKind.Unspecified\n" +
+                "};");
         }
 
         [Fact]

--- a/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
+++ b/Tests/ObjectDumper.Tests/ObjectDumperConsoleTests.cs
@@ -162,9 +162,11 @@ namespace ObjectDumping.Tests
 
             var options = new DumpOptions
             {
-                IndentChar = '\t',
                 IndentSize = 1,
-                SetPropertiesOnly = true
+                IndentChar = '\t',
+                LineBreakChar = "\n",
+                SetPropertiesOnly = true,
+                MemberRenamer = m => m == "Name" ? "RenamedName" : m,
             };
 
             // Act
@@ -173,25 +175,25 @@ namespace ObjectDumping.Tests
             // Assert
             this.testOutputHelper.WriteLine(dump);
             dump.Should().NotBeNull();
-            dump.Should().Be("{Person}\r\n" +
-                "	Name: \"Person 1\"\r\n" +
-                "	Char: ''\r\n" +
-                "	Age: 2\r\n" +
-                "	Bool: false\r\n" +
-                "	Byte: 0\r\n	ByteArray: ...\r\n" +
-                "		1\r\n" +
-                "		2\r\n" +
-                "		3\r\n" +
-                "		4\r\n" +
-                "	SByte: 0\r\n" +
-                "	Float: 0\r\n" +
-                "	Uint: 0\r\n" +
-                "	Long: 0\r\n	ULong: 0\r\n" +
-                "	Short: 0\r\n" +
-                "	UShort: 0\r\n" +
-                "	Decimal: 0\r\n" +
-                "	Double: 0\r\n	DateTime: DateTime.MinValue\r\n" +
-                "	NullableDateTime: null\r\n" +
+            dump.Should().Be("{Person}\n" +
+                "	RenamedName: \"Person 1\"\n" +
+                "	Char: ''\n" +
+                "	Age: 2\n" +
+                "	Bool: false\n" +
+                "	Byte: 0\n	ByteArray: ...\n" +
+                "		1\n" +
+                "		2\n" +
+                "		3\n" +
+                "		4\n" +
+                "	SByte: 0\n" +
+                "	Float: 0\n" +
+                "	Uint: 0\n" +
+                "	Long: 0\n	ULong: 0\n" +
+                "	Short: 0\n" +
+                "	UShort: 0\n" +
+                "	Decimal: 0\n" +
+                "	Double: 0\n	DateTime: DateTime.MinValue\n" +
+                "	NullableDateTime: null\n" +
                 "	Enum: DateTimeKind.Unspecified");
         }
 

--- a/build.yml
+++ b/build.yml
@@ -1,7 +1,7 @@
 ####################################################################
 # VSTS Build Configuration, Version 1.4
 #
-# (c)2021 superdev GmbH
+# (c)2022 superdev GmbH
 ####################################################################
 
 name: $[format('{0}', variables['buildName'])]


### PR DESCRIPTION
In some cases it is needed to return properties renamed. For example many embedded languages libs expose clr members under different name by default (Scriban, Moonsharp..). This PR adds a simple function we can pipe property name through and modify it before it is commited. This is nonbreaking change.