### PR TITLE
Escape C# Keywords when they are used as Propertynames

### DIFF
--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -13,6 +12,9 @@ namespace ObjectDumping.Internal
     /// </summary>
     internal class ObjectDumperCSharp : DumperBase
     {
+
+        private readonly string[] languageKeywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while" };
+
         public ObjectDumperCSharp(DumpOptions dumpOptions) : base(dumpOptions)
         {
         }
@@ -106,7 +108,7 @@ namespace ObjectDumping.Internal
 
                 if (this.CheckForCircularReference(value))
                 {
-                    this.Write($"{this.ResolvePropertyName(propertiesAndValue.Property.Name)} = ");
+                    this.Write($"{this.EscapeCsharpKeywords(this.ResolvePropertyName(propertiesAndValue.Property.Name))} = ");
                     this.FormatValue(propertiesAndValue.DefaultValue);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {
@@ -135,7 +137,7 @@ namespace ObjectDumping.Internal
                 }
                 else
                 {
-                    this.Write($"{this.ResolvePropertyName(propertiesAndValue.Property.Name)} = ");
+                    this.Write($"{this.EscapeCsharpKeywords(this.ResolvePropertyName(propertiesAndValue.Property.Name))} = ");
                     this.FormatValue(value);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {
@@ -632,6 +634,16 @@ namespace ObjectDumping.Internal
             }
 
             return variableName.ToLowerFirst();
+        }
+
+        private string EscapeCsharpKeywords(string name)
+        {
+            if (this.languageKeywords.Contains(name))
+            {
+                return $"@{name}";
+            }
+
+            return name;
         }
     }
 }

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -13,7 +13,7 @@ namespace ObjectDumping.Internal
     /// </summary>
     internal class ObjectDumperCSharp : DumperBase
     {
-		private readonly string[] languageKeywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while" };
+        private static readonly string[] LanguageKeywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while" };
 		
         public ObjectDumperCSharp(DumpOptions dumpOptions) : base(dumpOptions)
         {
@@ -108,7 +108,7 @@ namespace ObjectDumping.Internal
 
                 if (this.CheckForCircularReference(value))
                 {
-                    this.Write($"{this.EscapeCsharpKeywords(this.ResolvePropertyName(propertiesAndValue.Property.Name))} = ");
+                    this.Write($"{this.EscapeCSharpKeywords(this.ResolvePropertyName(propertiesAndValue.Property.Name))} = ");
                     this.FormatValue(propertiesAndValue.DefaultValue);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {
@@ -137,7 +137,7 @@ namespace ObjectDumping.Internal
                 }
                 else
                 {
-                    this.Write($"{this.EscapeCsharpKeywords(this.ResolvePropertyName(propertiesAndValue.Property.Name))} = ");
+                    this.Write($"{this.EscapeCSharpKeywords(this.ResolvePropertyName(propertiesAndValue.Property.Name))} = ");
                     this.FormatValue(value);
                     if (!Equals(propertiesAndValue, lastProperty))
                     {
@@ -636,9 +636,9 @@ namespace ObjectDumping.Internal
             return variableName.ToLowerFirst();
         }
         
-        private string EscapeCsharpKeywords(string name)
+        private string EscapeCSharpKeywords(string name)
         {
-            if (this.languageKeywords.Contains(name))
+            if (LanguageKeywords.Contains(name))
             {
                 return $"@{name}";
             }

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -12,9 +13,8 @@ namespace ObjectDumping.Internal
     /// </summary>
     internal class ObjectDumperCSharp : DumperBase
     {
-
-        private readonly string[] languageKeywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while" };
-
+		private readonly string[] languageKeywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while" };
+		
         public ObjectDumperCSharp(DumpOptions dumpOptions) : base(dumpOptions)
         {
         }
@@ -635,7 +635,7 @@ namespace ObjectDumping.Internal
 
             return variableName.ToLowerFirst();
         }
-
+        
         private string EscapeCsharpKeywords(string name)
         {
             if (this.languageKeywords.Contains(name))

--- a/Samples/ObjectDumperConsoleApp/ObjectDumperConsoleApp.csproj
+++ b/Samples/ObjectDumperConsoleApp/ObjectDumperConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.yml
+++ b/build.yml
@@ -26,7 +26,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   majorVersion: 3
-  minorVersion: 4
+  minorVersion: 5
   patchVersion: $[counter(format('{0}.{1}', variables.majorVersion, variables.minorVersion), 0)]
   ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
     # Versioning: 1.0.0

--- a/build.yml
+++ b/build.yml
@@ -7,7 +7,7 @@
 name: $[format('{0}', variables['buildName'])]
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 trigger:
   branches:
@@ -19,9 +19,7 @@ trigger:
 
   paths:
     exclude:
-    - README.md
-    - Images/*
-    - Samples/*
+    - Docs/*
 
 variables:
   solution: 'ObjectDumper.sln'
@@ -69,24 +67,22 @@ steps:
     FailOnWarning: false
     DisableTelemetry: false'
 
-
 - task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 5.x'
+  displayName: 'Use NuGet 6.x'
   inputs:
-    versionSpec: 5.x
+    versionSpec: 6.x
 
-- task: NuGetCommand@2
+- task: DotNetCoreCLI@2
   displayName: 'NuGet restore'
   inputs:
-    restoreSolution: '$(solution)'
+    command: restore
+    projects: '$(solution)'
 
-- task: VSBuild@1
+- task: DotNetCoreCLI@2
   displayName: 'Build solution'
   inputs:
-    solution: '$(solution)'
-    msbuildArgs: ''
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+    projects: '$(solution)'
+    arguments: '--no-restore --configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: 'Run UnitTests'
@@ -110,7 +106,7 @@ steps:
     packagesToPack: ObjectDumper/ObjectDumper.csproj
     versioningScheme: byEnvVar
     versionEnvVar: semVersion
-    
+
 - task: CopyFiles@2
   displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
   inputs:


### PR DESCRIPTION
I had the issues that I tried to dump an object structure which was generated from a XSD file. 
Unfortunately the creator of the XSD File used Names like "object" and "readonly" as variable Names on objects.

In C# this names can only be used when they are escaped with an @ Sign, so I added a List of all C# Keywords and check if the Propertyname is within the List and escape the name with @ when it is found.