### PR TITLE
Add version information

### DIFF
--- a/ObjectDumper/ObjectDumper.csproj
+++ b/ObjectDumper/ObjectDumper.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>ObjectDumper is a utility which aims to serialize C# objects to string for debugging and logging purposes.</Description>
     <AssemblyTitle>ObjectDumper</AssemblyTitle>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <Version>1.0.0</Version>
+    <VersionPrefix></VersionPrefix>
+    <Version>3.5.6</Version>
     <Authors>Thomas Galliker</Authors>
     <TargetFrameworks>net45;netstandard1.2;netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>ObjectDumping</AssemblyName>


### PR DESCRIPTION
Sync the version information with what's released to Nuget and should be updated for each release AssemblyVersion is automatically built to match Version unless otherwise specified. VersionPrefix is blank since it's not beta or alpha