### PR TITLE
Allowed to use AddFormatter with Types obtained through reflection

### DIFF
--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -72,11 +72,21 @@ public class CustomInstanceFormatters
 {
     private readonly Dictionary<Type, CustomInstanceFormatter> customFormatters = new Dictionary<Type, CustomInstanceFormatter>();
 
+    /// <summary>
+    /// Adds a custom type formatter for type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The target type.</typeparam>
+    /// <param name="formatInstance">The function which formats an object of type <typeparamref name="T"/> to string.</param>
     public void AddFormatter<T>(Func<T, string> formatInstance)
     {
-        this.customFormatters.Add(typeof(T), new CustomInstanceFormatter(typeof(T), o => formatInstance((T)o)));
+        this.AddFormatter(typeof(T), x => formatInstance((T)x));
     }
 
+    /// <summary>
+    /// Adds a custom type formatter for the given <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The target type.</param>
+    /// <param name="formatInstance">The function which formats an object of type <typeparamref name="T"/> to string.</param>
     public void AddFormatter(Type type, Func<object, string> formatInstance)
     {
         this.customFormatters.Add(type, new CustomInstanceFormatter(type, o => formatInstance(o)));

--- a/ObjectDumper/DumpOptions.cs
+++ b/ObjectDumper/DumpOptions.cs
@@ -77,6 +77,11 @@ public class CustomInstanceFormatters
         this.customFormatters.Add(typeof(T), new CustomInstanceFormatter(typeof(T), o => formatInstance((T)o)));
     }
 
+    public void AddFormatter(Type type, Func<object, string> formatInstance)
+    {
+        this.customFormatters.Add(type, new CustomInstanceFormatter(type, o => formatInstance(o)));
+    }
+
     public bool HasFormatterFor<T>()
     {
         return this.customFormatters.ContainsKey(typeof(T));


### PR DESCRIPTION
eg:

```csharp
  var type = typeof(CoreWebView2).Assembly.GetType("Microsoft.Web.WebView2.Core.COMStreamWrapper");
  var options = new DumpOptions()
  {
      DumpStyle = DumpStyle.CSharp
  };
  options.CustomInstanceFormatters.AddFormatter(type, o=>
   {
     ....
   });
```