### PR TITLE
feat: Allowed write dump on generic TextWriter

### DIFF
--- a/ObjectDumper/Extensions/ObjectDumperExtensions.cs
+++ b/ObjectDumper/Extensions/ObjectDumperExtensions.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 public static class ObjectDumperExtensions
 {
     /// <summary>
@@ -30,5 +32,40 @@ public static class ObjectDumperExtensions
     public static string Dump(this object element, DumpOptions dumpOptions)
     {
         return ObjectDumper.Dump(element, dumpOptions);
+    }
+
+    /// <summary>
+    ///     Serializes the given <see cref="element" /> to string.
+    /// </summary>
+    /// <param name="element">Object to be dumped to string using the default dump options.</param>
+    /// <param name="writer">Where <paramref name="element"/> will dump.</param>
+    /// <returns></returns>
+    public static void Dump(this object element, TextWriter writer)
+    {
+        ObjectDumper.Dump(element, writer, default);
+    }
+
+    /// <summary>
+    ///     Serializes the given <see cref="element" /> to string.
+    /// </summary>
+    /// <param name="element">Object to be dumped to string using the given <paramref name="dumpStyle" />.</param>
+    /// <param name="writer">Where <paramref name="element"/> will dump.</param>
+    /// <param name="dumpStyle">The formatting style.</param>
+    /// <returns></returns>
+    public static void Dump(this object element, TextWriter writer, DumpStyle dumpStyle)
+    {
+        ObjectDumper.Dump(element, writer, new() { DumpStyle = dumpStyle });
+    }
+
+    /// <summary>
+    ///     Serializes the given <see cref="element" /> to string with additional options <see cref="dumpOptions" />.
+    /// </summary>
+    /// <param name="element">Object to be dumped to string using the given <paramref name="dumpOptions" />.</param>
+    /// <param name="writer">Where <paramref name="element"/> will dump.</param>
+    /// <param name="dumpOptions">Further options to customize the dump output.</param>
+    /// <returns></returns>
+    public static void Dump(this object element, TextWriter writer, DumpOptions dumpOptions)
+    {
+        ObjectDumper.Dump(element, writer, dumpOptions);
     }
 }

--- a/ObjectDumper/Internal/DumperBase.cs
+++ b/ObjectDumper/Internal/DumperBase.cs
@@ -5,17 +5,22 @@ namespace ObjectDumping.Internal
     public abstract class DumperBase
     {
         private readonly CircularReferenceDetector circularReferenceDetector;
-        private readonly StringBuilder stringBuilder;
+        private readonly TextWriter writer;
         private bool isNewLine;
         private int level;
 
         protected DumperBase(DumpOptions dumpOptions)
+            : this(new StringWriter(new StringBuilder()), dumpOptions)
+        {
+        }
+
+        protected DumperBase(TextWriter writer, DumpOptions dumpOptions)
         {
             this.DumpOptions = dumpOptions;
             this.Level = 0;
-            this.stringBuilder = new StringBuilder();
             this.circularReferenceDetector = new CircularReferenceDetector();
             this.isNewLine = true;
+            this.writer = writer;
         }
 
         public int Level
@@ -67,8 +72,37 @@ namespace ObjectDumping.Internal
         /// <param name="indentLevel">number of indentions to prepend default 0</param>
         protected void Write(string value, int indentLevel = 0)
         {
-            this.stringBuilder.Append(this.DumpOptions.IndentChar, indentLevel * this.DumpOptions.IndentSize);
-            this.stringBuilder.Append(value);
+            for (var i = 0; i < indentLevel * this.DumpOptions.IndentSize; i++)
+            {
+                this.writer.Write(this.DumpOptions.IndentChar);
+            }
+
+            this.writer.Write(value);
+
+            if (value.EndsWith(this.DumpOptions.LineBreakChar))
+            {
+                this.isNewLine = true;
+            }
+            else
+            {
+                this.isNewLine = false;
+            }
+        }
+
+        protected async Task WriteAsync(string value, int indentLevel = 0, CancellationToken token = default)
+        {
+            for (var i = 0; i < indentLevel * this.DumpOptions.IndentSize; i++)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                this.writer.Write(this.DumpOptions.IndentChar);
+            }
+
+            await this.writer.WriteAsync(value);
+
             if (value.EndsWith(this.DumpOptions.LineBreakChar))
             {
                 this.isNewLine = true;
@@ -87,7 +121,19 @@ namespace ObjectDumping.Internal
         /// </remarks>
         protected void LineBreak()
         {
-            this.stringBuilder.Append(this.DumpOptions.LineBreakChar);
+            this.writer.Write(this.DumpOptions.LineBreakChar);
+            this.isNewLine = true;
+        }
+
+        /// <summary>
+        /// Writes a line break to underlying <see cref="StringBuilder"/> using <see cref="DumpOptions.LineBreakChar"/>
+        /// </summary>
+        /// <remarks>
+        /// By definition this sets isNewLine to true
+        /// </remarks>
+        protected async Task LineBreakAsync()
+        {
+            await this.writer.WriteAsync(this.DumpOptions.LineBreakChar);
             this.isNewLine = true;
         }
 
@@ -174,6 +220,11 @@ namespace ObjectDumping.Internal
             return name;
         }
 
+        protected async Task FlushAsync()
+        {
+            await this.writer.FlushAsync();
+        }
+
         /// <summary>
         /// Converts the value of this instance to a <see cref="string"/>
         /// </summary>
@@ -186,7 +237,8 @@ namespace ObjectDumping.Internal
                     "CircularReferenceDetector: Something went wrong if the circular reference detector stack is not empty at this time");
             }
 
-            return this.stringBuilder.ToString();
+            this.writer.Flush();
+            return this.writer.ToString() ?? string.Empty;
         }
     }
 }

--- a/ObjectDumper/Internal/ObjectDumperCSharp.cs
+++ b/ObjectDumper/Internal/ObjectDumperCSharp.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Globalization;
 using System.Reflection;
+using System.Text;
 
 namespace ObjectDumping.Internal
 {
@@ -13,6 +14,11 @@ namespace ObjectDumping.Internal
         private const string CircularReferenceDetectedComment = "// Circular reference detected";
         private static readonly string[] LanguageKeywords = { "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while" };
 
+        public ObjectDumperCSharp(TextWriter writer, DumpOptions? dumpOptions = null)
+           : base(writer, dumpOptions ?? new DumpOptions())
+        {
+
+        }
         public ObjectDumperCSharp(DumpOptions dumpOptions) : base(dumpOptions)
         {
         }
@@ -20,8 +26,9 @@ namespace ObjectDumping.Internal
         public static string Dump(object? element, DumpOptions? dumpOptions = null)
         {
             dumpOptions ??= new DumpOptions();
+            var writer = new StringWriter(new StringBuilder());
 
-            var instance = new ObjectDumperCSharp(dumpOptions);
+            var instance = new ObjectDumperCSharp(writer, dumpOptions);
             if (!dumpOptions.TrimInitialVariableName)
             {
                 instance.Write($"var {instance.GetVariableName(element)} = ");
@@ -35,6 +42,27 @@ namespace ObjectDumping.Internal
 
             return instance.ToString();
         }
+
+        public static void Dump(object element, TextWriter writer, DumpOptions? dumpOptions = null)
+        {
+            dumpOptions ??= new DumpOptions();
+            writer ??= new StringWriter(new StringBuilder());
+
+            var instance = new ObjectDumperCSharp(writer, dumpOptions);
+            if (!dumpOptions.TrimInitialVariableName)
+            {
+                instance.Write($"var {instance.GetVariableName(element)} = ");
+            }
+
+            instance.FormatValue(element);
+            if (!dumpOptions.TrimTrailingColonName)
+            {
+                instance.Write(";");
+            }
+
+            writer.Flush();
+        }
+
 
         private void CreateObject(object o, int intentLevel = 0)
         {

--- a/ObjectDumper/Internal/ObjectDumperConsole.cs
+++ b/ObjectDumper/Internal/ObjectDumperConsole.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Globalization;
 using System.Reflection;
+using System.Text;
 
 namespace ObjectDumping.Internal
 {
@@ -12,15 +13,32 @@ namespace ObjectDumping.Internal
         {
         }
 
+        public ObjectDumperConsole(TextWriter writer, DumpOptions? dumpOptions = null) : base(writer, dumpOptions ?? new())
+        {
+        }
+
         public static string Dump(object? element, DumpOptions? dumpOptions = null)
         {
             dumpOptions ??= new DumpOptions();
 
-            var instance = new ObjectDumperConsole(dumpOptions);
+            var writer = new StringWriter(new StringBuilder());
+            Dump(element, writer, dumpOptions);
+            return writer.ToString();
+        }
 
+        public static void Dump(object? element, TextWriter writer, DumpOptions? dumpOptions = null)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer), $"Parameter 'nameof(writer)' must not be null.");
+            }
+
+            dumpOptions ??= new DumpOptions();
+
+            var instance = new ObjectDumperConsole(writer, dumpOptions);
             instance.FormatValue(element);
 
-            return instance.ToString();
+            writer.Flush();
         }
 
         private void CreateObject(object o, int intentLevel = 0)

--- a/ObjectDumper/ObjectDumper.cs
+++ b/ObjectDumper/ObjectDumper.cs
@@ -1,10 +1,11 @@
+using System.IO;
 using ObjectDumping.Internal;
 
 // ReSharper disable once CheckNamespace
 public static class ObjectDumper
 {
     /// <summary>
-    ///     Serializes the given <see cref="element" /> to string.
+    /// Serializes the given <see cref="element" /> to string.
     /// </summary>
     /// <param name="element">Object to be dumped to string using the default dump options.</param>
     /// <returns></returns>
@@ -15,7 +16,7 @@ public static class ObjectDumper
     }
 
     /// <summary>
-    ///     Serializes the given <see cref="element" /> to string.
+    /// Serializes the given <see cref="element" /> to string.
     /// </summary>
     /// <param name="element">Object to be dumped to string using the given <paramref name="dumpStyle" />.</param>
     /// <param name="dumpStyle">The formatting style.</param>
@@ -27,7 +28,7 @@ public static class ObjectDumper
     }
 
     /// <summary>
-    ///     Serializes the given <see cref="element" /> to string with additional options <see cref="dumpOptions" />.
+    /// Serializes the given <see cref="element" /> to string with additional options <see cref="dumpOptions" />.
     /// </summary>
     /// <param name="element">Object to be dumped to string using the given <paramref name="dumpOptions" />.</param>
     /// <param name="dumpOptions">Further options to customize the dump output.</param>
@@ -46,4 +47,28 @@ public static class ObjectDumper
 
         return ObjectDumperCSharp.Dump(element, dumpOptions);
     }
+
+    /// <summary>
+    /// Serializes the given <see cref="element" /> to string with additional options <see cref="dumpOptions" />.
+    /// </summary>
+    /// <param name="element">Object to be dumped to string using the given <paramref name="dumpOptions" />.</param>
+    /// <param name="writer">Where <paramref name="element"/> is write.</param>
+    /// <param name="dumpOptions">Further options to customize the dump output.</param>
+    public static void Dump(object element, TextWriter writer, DumpOptions? dumpOptions)
+    {
+        dumpOptions ??= new DumpOptions();
+
+        switch (dumpOptions.DumpStyle)
+        {
+            case DumpStyle.Console:
+                ObjectDumperCSharp.Dump(element, writer, dumpOptions);
+                break;
+            case DumpStyle.CSharp:
+                ObjectDumperConsole.Dump(element, writer, dumpOptions);
+                break;
+            default:
+                break;
+        }
+    }
+
 }


### PR DESCRIPTION

eg:

```c#
    var persons = new List<Person>
    {
        new Person { Name = "John", Age = 20, },
        new Person { Name = "Thomas", Age = 30, },
    };
    
    // Dump persons object directly into console output without going through a StringBuilder
    persons.Dump(Console.Out);
``` 
